### PR TITLE
SRVLOGIC-83: Remove "Kogito" name from Serverless Logic documents

### DIFF
--- a/serverlessworkflow/modules/ROOT/pages/core/custom-functions-support.adoc
+++ b/serverlessworkflow/modules/ROOT/pages/core/custom-functions-support.adoc
@@ -162,7 +162,7 @@ If your method returns a primitive type or their corresponding wrapper object (i
 
 If your method returns Java collections, it is converted to a JSON array and added to the workflow model with the name `response` (you can change that name using an action data filter).
 
-=== Function accessing {product_name} context
+=== Function accessing contextual data
 
 If you need access to process contextual information (for example, Kogito process instance ID) inside your Java service, you can add a `KogitoProcessContext` parameter as the last one in the method signature.
 

--- a/serverlessworkflow/modules/ROOT/pages/core/custom-functions-support.adoc
+++ b/serverlessworkflow/modules/ROOT/pages/core/custom-functions-support.adoc
@@ -33,7 +33,7 @@ You can use the `sysout` function for logging as shown in the following example:
 }
 ----
 
-The string after the `:` is optional and is used to indicate the log level.  The possible values are TRACE, DEBUG, INFO, WARN, and ERROR. If not present, INFO is considered by default. 
+The string after the `:` is optional and is used to indicate the log level.  The possible values are TRACE, DEBUG, INFO, WARN, and ERROR. If not present, INFO is considered by default.
 
 In the `state` definition, you can call the same `sysout` function as shown in the following example:
 
@@ -162,7 +162,7 @@ If your method returns a primitive type or their corresponding wrapper object (i
 
 If your method returns Java collections, it is converted to a JSON array and added to the workflow model with the name `response` (you can change that name using an action data filter).
 
-=== Function accessing Kogito context
+=== Function accessing {product_name} context
 
 If you need access to process contextual information (for example, Kogito process instance ID) inside your Java service, you can add a `KogitoProcessContext` parameter as the last one in the method signature.
 


### PR DESCRIPTION
Tracking JIRA: https://issues.redhat.com/browse/SRVLOGIC-83

I am currently using and referring to this link: [About OpenShift Serverless Logic](https://openshift-knative.github.io/docs/docs/latest/serverless-logic/about.html)
Is this the correct resource I am referring to?