### PR TITLE
Update `kiegroup` repository references to `apache`

### DIFF
--- a/.ci/jenkins/Jenkinsfile.post-release
+++ b/.ci/jenkins/Jenkinsfile.post-release
@@ -38,7 +38,7 @@ pipeline {
                 script {
                     dir("kogito-docs-${getBuildBranch()}") {
                         deleteDir()
-                        checkout(githubscm.resolveRepository('kogito-docs', getGitAuthor(), getBuildBranch(), false, getGitAuthorCredsID()))
+                        checkout(githubscm.resolveRepository('incubator-kie-kogito-docs', getGitAuthor(), getBuildBranch(), false, getGitAuthorCredsID()))
                         sh "git checkout ${getBuildBranch()}"
 
                         String antoraFile = 'serverlessworkflow/antora.yml'

--- a/.ci/jenkins/Jenkinsfile.setup-branch
+++ b/.ci/jenkins/Jenkinsfile.setup-branch
@@ -48,7 +48,7 @@ pipeline {
                         String displayVersion = "${branchSplit[0]}.${branchSplit[1]}-RC"
                         String version = "${branchSplit[0]}.${branchSplit[1]}.0-SNAPSHOT"
                         String prereleaseStr = 'rc'
-                        String swExamplesURL = "https://github.com/apache/kogito-examples/tree/${getBuildBranch()}/serverless-workflow-examples"
+                        String swExamplesURL = "https://github.com/apache/incubator-kie-kogito-examples/tree/${getBuildBranch()}/serverless-workflow-examples"
                         String antoraFile = 'serverlessworkflow/antora.yml'
                         String operatorVersion = "${getBuildBranch()}"
 

--- a/.ci/jenkins/Jenkinsfile.setup-branch
+++ b/.ci/jenkins/Jenkinsfile.setup-branch
@@ -48,7 +48,7 @@ pipeline {
                         String displayVersion = "${branchSplit[0]}.${branchSplit[1]}-RC"
                         String version = "${branchSplit[0]}.${branchSplit[1]}.0-SNAPSHOT"
                         String prereleaseStr = 'rc'
-                        String swExamplesURL = "https://github.com/kiegroup/kogito-examples/tree/${getBuildBranch()}/serverless-workflow-examples"
+                        String swExamplesURL = "https://github.com/apache/kogito-examples/tree/${getBuildBranch()}/serverless-workflow-examples"
                         String antoraFile = 'serverlessworkflow/antora.yml'
                         String operatorVersion = "${getBuildBranch()}"
 

--- a/.ci/jenkins/Jenkinsfile.setup-branch
+++ b/.ci/jenkins/Jenkinsfile.setup-branch
@@ -41,7 +41,7 @@ pipeline {
 
                     dir("kogito-docs-${getBuildBranch()}") {
                         deleteDir()
-                        checkout(githubscm.resolveRepository('kogito-docs', getGitAuthor(), getBuildBranch(), false, getGitAuthorCredsID()))
+                        checkout(githubscm.resolveRepository('incubator-kie-kogito-docs', getGitAuthor(), getBuildBranch(), false, getGitAuthorCredsID()))
                         sh "git checkout ${getBuildBranch()}"
 
                         String[] branchSplit = getBuildBranch().split("\\.")
@@ -77,7 +77,7 @@ pipeline {
                 script {
                     dir('kogito-docs') {
                         deleteDir()
-                        checkout(githubscm.resolveRepository('kogito-docs', getGitAuthor(), 'main', false, getGitAuthorCredsID()))
+                        checkout(githubscm.resolveRepository('incubator-kie-kogito-docs', getGitAuthor(), 'main', false, getGitAuthorCredsID()))
                         sh 'git checkout main'
 
                         updateYaml('antora-playbook.yml') { antoraConfig ->

--- a/.ci/jenkins/dsl/jobs.groovy
+++ b/.ci/jenkins/dsl/jobs.groovy
@@ -2,10 +2,10 @@
 * This file is describing all the Jenkins jobs in the DSL format (see https://plugins.jenkins.io/job-dsl/)
 * needed by the Kogito pipelines.
 *
-* The main part of Jenkins job generation is defined into the https://github.com/apache/kogito-pipelines repository.
+* The main part of Jenkins job generation is defined into the https://github.com/apache/incubator-kie-kogito-pipelines repository.
 *
 * This file is making use of shared libraries defined in
-* https://github.com/apache/kogito-pipelines/tree/main/dsl/seed/src/main/groovy/org/kie/jenkins/jobdsl.
+* https://github.com/apache/incubator-kie-kogito-pipelines/tree/main/dsl/seed/src/main/groovy/org/kie/jenkins/jobdsl.
 */
 
 import org.kie.jenkins.jobdsl.model.JobType

--- a/.ci/jenkins/dsl/jobs.groovy
+++ b/.ci/jenkins/dsl/jobs.groovy
@@ -2,10 +2,10 @@
 * This file is describing all the Jenkins jobs in the DSL format (see https://plugins.jenkins.io/job-dsl/)
 * needed by the Kogito pipelines.
 *
-* The main part of Jenkins job generation is defined into the https://github.com/kiegroup/kogito-pipelines repository.
+* The main part of Jenkins job generation is defined into the https://github.com/apache/kogito-pipelines repository.
 *
 * This file is making use of shared libraries defined in
-* https://github.com/kiegroup/kogito-pipelines/tree/main/dsl/seed/src/main/groovy/org/kie/jenkins/jobdsl.
+* https://github.com/apache/kogito-pipelines/tree/main/dsl/seed/src/main/groovy/org/kie/jenkins/jobdsl.
 */
 
 import org.kie.jenkins.jobdsl.model.JobType

--- a/.ci/jenkins/dsl/test.sh
+++ b/.ci/jenkins/dsl/test.sh
@@ -1,6 +1,6 @@
 #!/bin/bash -e
 file=$(mktemp)
 # For more usage of the script, use ./test.sh -h
-curl -o ${file} https://raw.githubusercontent.com/apache/kogito-pipelines/main/dsl/seed/scripts/seed_test.sh
+curl -o ${file} https://raw.githubusercontent.com/apache/incubator-kie-kogito-pipelines/main/dsl/seed/scripts/seed_test.sh
 chmod u+x ${file}
 ${file} $@

--- a/.ci/jenkins/dsl/test.sh
+++ b/.ci/jenkins/dsl/test.sh
@@ -1,6 +1,6 @@
 #!/bin/bash -e
 file=$(mktemp)
 # For more usage of the script, use ./test.sh -h
-curl -o ${file} https://raw.githubusercontent.com/kiegroup/kogito-pipelines/main/dsl/seed/scripts/seed_test.sh
+curl -o ${file} https://raw.githubusercontent.com/apache/kogito-pipelines/main/dsl/seed/scripts/seed_test.sh
 chmod u+x ${file}
 ${file} $@

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -8,7 +8,7 @@
 
 Please make sure that your PR meets the following requirements:
 
-- [ ] You have read the [contributions doc](https://github.com/kiegroup/kogito-docs/blob/main/CONTRIBUTING.md)
+- [ ] You have read the [contributions doc](https://github.com/apache/kogito-docs/blob/main/CONTRIBUTING.md)
 - [ ] Pull Request title is properly formatted: `KOGITO-XYZ Subject`
 - [ ] Pull Request title contains the target branch if not targeting main: `[0.9.x] KOGITO-XYZ Subject`
 - [ ] The nav.adoc file has a link to this guide in the proper category

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -8,7 +8,7 @@
 
 Please make sure that your PR meets the following requirements:
 
-- [ ] You have read the [contributions doc](https://github.com/apache/kogito-docs/blob/main/CONTRIBUTING.md)
+- [ ] You have read the [contributions doc](https://github.com/apache/incubator-kie-kogito-docs/blob/main/CONTRIBUTING.md)
 - [ ] Pull Request title is properly formatted: `KOGITO-XYZ Subject`
 - [ ] Pull Request title contains the target branch if not targeting main: `[0.9.x] KOGITO-XYZ Subject`
 - [ ] The nav.adoc file has a link to this guide in the proper category

--- a/.github/workflows/jenkins-tests-PR.yml
+++ b/.github/workflows/jenkins-tests-PR.yml
@@ -17,6 +17,6 @@ jobs:
     - name: DSL tests
       uses: kiegroup/kie-ci/.ci/actions/dsl-tests@main
       with:
-        main-config-file-repo: kiegroup/kogito-pipelines
+        main-config-file-repo: apache/kogito-pipelines
         main-config-file-path: .ci/jenkins/config/main.yaml
-        branch-config-file-repo: kiegroup/kogito-pipelines
+        branch-config-file-repo: apache/kogito-pipelines

--- a/.github/workflows/jenkins-tests-PR.yml
+++ b/.github/workflows/jenkins-tests-PR.yml
@@ -17,6 +17,6 @@ jobs:
     - name: DSL tests
       uses: kiegroup/kie-ci/.ci/actions/dsl-tests@main
       with:
-        main-config-file-repo: apache/kogito-pipelines
+        main-config-file-repo: apache/incubator-kie-kogito-pipelines
         main-config-file-path: .ci/jenkins/config/main.yaml
-        branch-config-file-repo: apache/kogito-pipelines
+        branch-config-file-repo: apache/incubator-kie-kogito-pipelines


### PR DESCRIPTION
- https://github.com/kiegroup/kogito-pipelines/pull/1078
- https://github.com/kiegroup/kogito-runtimes/pull/3223
- https://github.com/kiegroup/kogito-examples/pull/1806
- https://github.com/kiegroup/kogito-apps/pull/1877
- https://github.com/kiegroup/kogito-images/pull/1698
- https://github.com/kiegroup/kogito-operator/pull/1528
- https://github.com/kiegroup/kogito-serverless-operator/pull/250
- https://github.com/kiegroup/kogito-docs/pull/497
- https://github.com/kiegroup/drools/pull/5519
- https://github.com/kiegroup/drools-website/pull/269
- https://github.com/radtriste/kie-benchmarks/pull/1 (WARNING: on `radtriste`, not on `kiegroup !`)
- https://github.com/asf-transfer/optaplanner/pull/2968
- https://github.com/kiegroup/optaplanner-quickstarts/pull/601