### PR TITLE
Fix kiegroup references and add github pages settings

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -1,0 +1,3 @@
+github:
+  ghp_branch:  gh-pages
+  ghp_path:    /

--- a/.github/workflows/sw-docs-pr.yml
+++ b/.github/workflows/sw-docs-pr.yml
@@ -1,4 +1,4 @@
-name: Serverless Workflow Guides
+name: SonataFlow Guides
 
 on:
   pull_request:
@@ -10,7 +10,7 @@ on:
       - 'README*'
 jobs:
   build_site:
-    name: "Building Serverless Workflow Documentation with Antora"
+    name: "Building SonataFlow Guides with Antora"
     runs-on: [ubuntu-latest]
     steps:
       - uses: actions/checkout@v3

--- a/antora-playbook.yml
+++ b/antora-playbook.yml
@@ -9,7 +9,7 @@ antora:
     index_latest_only: true
 content:
   sources:
-  - url: git@github.com:kiegroup/kogito-docs.git
+  - url: git@github.com:apache/incubator-kie-kogito-docs.git
     branches:
     - main
     - 1.24.x
@@ -29,7 +29,6 @@ content:
     - 1.38.x
     - 1.39.x
     - 1.40.x
-    - 1.40.x-prod
     - 1.41.x
     - 1.42.x
     - 1.43.x

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "license": "Apache-2.0",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/kiegroup/kogito-docs.git"
+    "url": "git+https://github.com/apache/incubator-kie-kogito-docs.git"
   },
   "scripts": {
     "local-install-build": "npm i && npx antora antora-playbook-author.yml --stacktrace",

--- a/serverlessworkflow/antora.yml
+++ b/serverlessworkflow/antora.yml
@@ -90,7 +90,7 @@ asciidoc:
     kaoto_url: https://marketplace.visualstudio.com/items?itemName=redhat.vscode-kaoto
     minikube_url: https://minikube.sigs.k8s.io
     kogito_serverless_operator_url: https://github.com/kiegroup/kogito-serverless-operator/
-    docs_issues_url: https://github.com/kiegroup/kogito-docs/issues/new
+    docs_issues_url: https://github.com/apache/incubator-kie-kogito-docs/issues/new
     ocp_local_url: https://access.redhat.com/documentation/en-us/red_hat_openshift_local/2.17
     ocp_knative_serving_url: https://docs.openshift.com/container-platform/4.12/serverless/install/installing-knative-serving.html
     ocp_knative_eventing_url: https://docs.openshift.com/container-platform/4.12/serverless/install/installing-knative-eventing.html


### PR DESCRIPTION
In this PR, we fix all the old repo references when building the documentation website. Also added the `.asf.yaml` file to follow the best practices and configure the repository accordingly. See https://cwiki.apache.org/confluence/display/INFRA/Git+-+.asf.yaml+features#Git.asf.yamlfeatures-GitHubPages