### PR TITLE
Fix memory unit from "mi:" to "Mi"

### DIFF
--- a/serverlessworkflow/modules/ROOT/pages/cloud/operator/customize-podspec.adoc
+++ b/serverlessworkflow/modules/ROOT/pages/cloud/operator/customize-podspec.adoc
@@ -30,7 +30,7 @@ spec:
       resources: <3>
         limits:
           cpu: "250m"
-          memory: "128mi"
+          memory: "128Mi"
   flow:
     start: HelloWorld
     states:


### PR DESCRIPTION
Signed-off-by: Roy Golan <rgolan@redhat.com>
