### PR TITLE
Issue-522: Update contribution guide to point towards Github issues

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,7 +1,7 @@
-<!-- Please don't forget your JIRA link -->
-**JIRA:**
+<!-- Please don't forget your Issue link -->
+close/fixes #NUMBER
 
-<!-- If you don't have a JIRA link, please provide a short description of what this PR does -->
+<!-- Please provide a short description of what this PR does -->
 **Description:**
 
 <!-- Link to related PRs: -->
@@ -9,8 +9,8 @@
 Please make sure that your PR meets the following requirements:
 
 - [ ] You have read the [contributions doc](https://github.com/apache/incubator-kie-kogito-docs/blob/main/CONTRIBUTING.md)
-- [ ] Pull Request title is properly formatted: `KOGITO-XYZ Subject`
-- [ ] Pull Request title contains the target branch if not targeting main: `[0.9.x] KOGITO-XYZ Subject`
+- [ ] Pull Request title is properly formatted: `Issue-XYZ Subject`
+- [ ] Pull Request title contains the target branch if not targeting main: `[0.9.x] Issue-XYZ Subject`
 - [ ] The nav.adoc file has a link to this guide in the proper category
 - [ ] The index.adoc file has a card to this guide in the proper category, with a meaningful description
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -3,32 +3,32 @@
 We accept all kinds of contributions:
 
 1. Reviewing a PR
-2. Opening [an issue](issues) by describing what problem you see that we need to fix
-3. Opening [a PR](pulls) if you see a typo, broken link, or any other minor changes.
+2. Opening [an issue](https://github.com/apache/incubator-kie-kogito-docs/issues/new) by describing what problem you see that we need to fix
+3. Opening [a PR](https://github.com/apache/incubator-kie-kogito-docs/compare) if you see a typo, broken link, or any other minor changes.
 
-> To include a new guide or documentation content, please **open an issue first** so we can discuss in more detail what needs to be done. We use [JIRA](https://issues.redhat.com/) to track our tasks, so the issue is likely to turn into a JIRA issue.
+> To include a new guide or documentation content, please **open an issue first** so we can discuss in more detail what needs to be done. We use [Issues](https://github.com/apache/incubator-kie-kogito-docs/issues) to track our tasks. Please include a good title and thorought description.
 
 ## Including a new guide
 
-1. Open a JIRA issue and add a sub-task for Doc review. 
-2. Write the guide
+1. Open a [an issue](https://github.com/apache/incubator-kie-kogito-docs/issues/new) provide a description and link any pull-requests realted to the guide. 
+2. Write the guide.
 3. Add a link to the guide in [serverlessworkflow/modules/ROOT/nav.adoc](serverlessworkflow/modules/ROOT/nav.adoc)
 4. Add a card for the guide in [serverlessworkflow/modules/ROOT/pages/index.adoc](serverlessworkflow/modules/ROOT/pages/index.adoc)
+5. Submit a [a PR](https://github.com/apache/incubator-kie-kogito-docs/compare)
 
-## Opening a JIRA Issue
+## Opening an Issue
 
-1. Make sure to add a description of the guide you plan to add followed by the `[Kogito Guides]` prefix
-2. Clearly describe in which parent category you will publish the guide
-3. Create a sub-task with the title `[Docs Review][Kogito Guides] - JIRA Title` so that the Content Team can review your guide.
-4. After all SMEs have reviewed and approved your guide, change the status of the sub-task to "Pull Request Sent" by adding the PR link to the sub-task JIRA. This way, the documentation team will be notified and will review your PR.
+1. Make sure to add a good summarizing title and thorought description of the guide you plan to add. 
+2. Clearly describe in which parent category you will publish the guide.
+3. Ensure there are linked contribution realated to the guide, so that the Reviewer is able to understand the source.
 
 ### Following up a code change
 
-If your PR is to update a guide with a change you made in Kogito project code base, you don't need to create a new JIRA just to update the documentation.
+If your PR is to update a guide with a change you made in Kogito project code base, you don't need to create a new issue just to update the documentation.
 
-Use the same JIRA issue and make sure that your branch is called `kogito-NNNNN` where `NNNNN` is the JIRA number. This way, our automation will work and link all the PRs together among every repository impacted by your change.
+Use the same issue and make sure that your branches are called `kie-kogito-docs-#NNNN` where `NNNNN` is the issue number.
 
-For the documentation review, do the same step as described in the item number 4 in the previous section: open a sub-task in the JIRA issue.
+For the documentation review, do the same step as described in the item number 4 in the previous section: open an issue and use proper label.
 
 ## Basic Conventions
 


### PR DESCRIPTION
<!-- Please don't forget your JIRA link -->
Fixes #522 

<!-- If you don't have a JIRA link, please provide a short description of what this PR does -->
**Description:**

<!-- Link to related PRs: -->

Please make sure that your PR meets the following requirements:

- [ x] You have read the [contributions doc](https://github.com/apache/incubator-kie-kogito-docs/blob/main/CONTRIBUTING.md)
- [x ] Pull Request title is properly formatted: `KOGITO-XYZ Subject`
- [ x] Pull Request title contains the target branch if not targeting main: `[0.9.x] KOGITO-XYZ Subject`
- [ x] The nav.adoc file has a link to this guide in the proper category
- [ x] The index.adoc file has a card to this guide in the proper category, with a meaningful description

<details>
<summary>
How to backport a pull request to a different branch?
</summary>

In order to automatically create a **backporting pull request** please add one or more labels having the following format `backport-<branch-name>`, where `<branch-name>` is the name of the branch where the pull request must be backported to (e.g., `backport-7.67.x` to backport the original PR to the `7.67.x` branch).

> **NOTE**: **backporting** is an action aiming to move a change (usually a commit) from a branch (usually the main one) to another one, which is generally referring to a still maintained release branch. Keeping it simple: it is about to move a specific change or a set of them from one branch to another.

Once the original pull request is successfully merged, the automated action will create one backporting pull request per each label (with the previous format) that has been added.

If something goes wrong, the author will be notified and at this point a manual backporting is needed.

> **NOTE**: this automated backporting is triggered whenever a pull request on `main` branch is labeled or closed, but both conditions must be satisfied to get the new PR created.
</details>