### PR TITLE
[KOGITO-9940] Add documentation for Jobs Service support in the Operator

### DIFF
--- a/serverlessworkflow/modules/ROOT/pages/cloud/index.adoc
+++ b/serverlessworkflow/modules/ROOT/pages/cloud/index.adoc
@@ -32,6 +32,14 @@ Learn how to install the {operator_name} in a Kubernetes cluster
 [.card]
 --
 [.card-title]
+xref:cloud/operator/enabling-jobs-service.adoc[]
+[.card-description]
+Learn how to deploy the Jobs Service using {operator_name} in a Kubernetes cluster
+--
+
+[.card]
+--
+[.card-title]
 xref:cloud/operator/developing-workflows.adoc[]
 [.card-description]
 Learn how to deploy a workflow for development purposes

--- a/serverlessworkflow/modules/ROOT/pages/cloud/operator/enabling-jobs-service.adoc
+++ b/serverlessworkflow/modules/ROOT/pages/cloud/operator/enabling-jobs-service.adoc
@@ -1,0 +1,119 @@
+= Managing Jobs Service with the Operator
+:compat-mode!:
+// Metadata:
+:description: Configure Jobs Service using the SonataFlowPlatform CR.
+:keywords: sonataflow, serverless, operator, kubernetes, jobs service
+
+
+This document describes how to configure the Jobs Service instance usimg the SonataFlowPlarform CR.
+
+== Automate the Jobs Service instance management with the SonataFlow Operator
+
+While it is possible to deploy the Jobs Service manually, the Operator also provides a convenient way to combine it with the
+namespace configuration via the SonataFlowPlatform CR. With this approach, the Operator will take care of configuring the
+Jobs Service instance and ensure it is in sync with the specification in the CR. When the operator manages the Jobs Service lifecycle,
+it will inject properties in SonataFlow workflows at creation time to enable the workflows to communicate with the Jobs Service
+instance during their execution, removing the need to add these properties as part of the SonataFlow workflow CR instance.
+
+== Configuring Jobs Service in the SonataFlowPlatformCR
+
+To enable the deployment of a Jobs Service instance, the `SonataFlowPlatform` CRD exposes a set of fields that allow the user to 
+configure the running instance. 
+
+==== Ephemeral persistence
+The basic runtime is to deploy the Jobs Service with an ephemeral backend running in the same container
+as the Jobs Service runtime.
+
+[source,yaml,subs="attributes+"]
+---
+apiVersion: sonataflow.org/v1alpha08
+kind: SonataFlowPlatform
+metadata:
+  name: sonataflow-platform
+spec:
+  services:
+    jobService: {}
+---
+
+When executing this manifest, the operator will reconcile generating a pod hosting the Jobs Service:
+
+[source,yaml,subs="attributes+"]
+---
+$>kubectl get pod -n sonataflow
+NAME                                               READY   STATUS    RESTARTS   AGE
+sonataflow-platform-jobs-service-cdf85d969-sbwkj   1/1     Running   0          108s
+---
+
+Keep in mind that this setup is not recommended for production environments, chiefly because the data is not persisted when the pod restarts.
+
+==== Using an existing postgreSQL service
+For robust environments it is recommened to use an dedicated database service and configure Jobs Service to make use of it. Currently, the Jobs Service
+only supports PostgreSQL database.
+
+To configure Jobs Service to communicate with an existing PostgreSQL instance running in the same cluster you will need to specify the secret that contains
+the credentials to authenticate with the database, and then define the kubernetes service specification:
+
+[source,yaml,subs="attributes+"]
+---
+apiVersion: sonataflow.org/v1alpha08
+kind: SonataFlow
+metadata:
+  name: callbackstatetimeouts
+spec:
+  persistence:
+    postgresql:
+      secretRef:
+        name: postgres-secrets
+        userKey: POSTGRES_USER
+        passwordKey: POSTGRES_PASSWORD
+      serviceRef:
+        name: postgres
+        port: 5432
+        databaseName: sonataflow
+        databaseSchema: jobs-service
+---
+
+In this example we're using a PostgreSQL service located in the same namespace where the Jobs Service is deployed, pointing to the default PostgreSQL port of 5432
+and referencing the database `sonataflow` and schema `jobs-service`. By default, when the Jobs Service pod starts it will recreate the schema in the given location
+if it doesn't exist.
+
+The values of `POSTGRES_USER` and `POSTGRES_PASSWORD` point to the keys in the secret that contains the PostgreSQL credentials.
+
+[source,yaml,subs="attributes+"]
+---
+$>kubectl describe secrets postgres-secrets
+Name:         postgres-secrets
+Namespace:    default
+Labels:       <none>
+Annotations:  <none>
+
+Type:  Opaque
+
+Data
+====
+PGDATA:             28 bytes
+POSTGRES_DATABASE:  10 bytes
+POSTGRES_PASSWORD:  10 bytes
+POSTGRES_USER:      10 bytes
+---
+
+Putting everything together will render an output similar to this one below:
+
+[source,yaml,subs="attributes+"]
+---
+$>kubectl get pod -w -n sonataflow
+NAME                                                READY   STATUS    RESTARTS   AGE
+postgres-64c9ddb6bc-v96qb                           1/1     Running   0          14m
+sonataflow-platform-jobs-service-79bb6bc67f-gvcg4   1/1     Running   0           1m
+---
+
+== Conclusion
+The Operator extends its scope to manage the lifecycle of the Jobs Service instance, thus removing the burden to the users and allowing them to focus on the
+implementation of the SonataFlow workflows. It takes care of managing the Jobs Service deployment, dynamically configure its application properties
+when the Data Index service is also available and managed by the Operator, and finally inject application properties in SonataFlow workflows in the target
+namespace when the Jobs Service is available.
+
+== Additional resources
+* xref:cloud/operator/install-serverless-operator.adoc[]
+
+include::../../../pages/_common-content/report-issue.adoc[]

--- a/serverlessworkflow/modules/ROOT/pages/cloud/operator/enabling-jobs-service.adoc
+++ b/serverlessworkflow/modules/ROOT/pages/cloud/operator/enabling-jobs-service.adoc
@@ -44,7 +44,7 @@ NAME                                               READY   STATUS    RESTARTS   
 sonataflow-platform-jobs-service-cdf85d969-sbwkj   1/1     Running   0          108s
 ---
 
-Keep in mind that this setup is not recommended for production environments, chiefly because the data is not persisted when the pod restarts.
+Keep in mind that this setup is not recommended for production environments, especially because the data does not persist when the pod restarts.
 
 ==== Using an existing postgreSQL service
 For robust environments it is recommened to use an dedicated database service and configure Jobs Service to make use of it. Currently, the Jobs Service

--- a/serverlessworkflow/modules/ROOT/pages/cloud/operator/enabling-jobs-service.adoc
+++ b/serverlessworkflow/modules/ROOT/pages/cloud/operator/enabling-jobs-service.adoc
@@ -9,12 +9,10 @@ This document describes how to configure the Jobs Service instance using the Son
 
 == Automate the Jobs Service instance management with the `SonataFlow` Operator
 
-While it is possible to deploy the Jobs Service manually, the Operator also provides a convenient way to combine it with the
-namespace configuration via the `SonataFlowPlatform` CR. With this approach, the Operator will take care of configuring the
-Jobs Service instance and ensure it is in sync with the specification in the CR. When the operator manages the Jobs Service lifecycle,
-it will inject properties in `SonataFlow` workflows at creation time to enable the workflows to communicate with the Jobs Service
-It is possible to deploy the Jobs Service manually, but the Operator also provides a convenient way to combine it with the namespace configuration via the `SonataFlowPlatform` CR. This approach allows the Operator to configure the Jobs Service and make sure it is in line with the Specification in CR. When the Operator manages the jobs service lifecycle, it injects properties at creation time in the `SonataFlow` workflows to communicate with the Jobs Service during execution, eliminating the need to include these properties in the workflow CR instance of the `SonataFlow` workflow.
-
+It is possible to deploy the Jobs Service manually, leveraging the Operator offers a more seamless integration by
+combining it with namespace configuration through the SonataFlowPlatform Custom Resource (CR). When the Operator oversees
+the lifecycle of the jobs service, it automatically injects necessary properties during creation into the SonataFlow workflows.
+This integration eliminates the need for including these properties within the SonataFlow workflow CR instance, simplifying workflow management.
 == Configuring Jobs Service in the SonataFlowPlatform CR
 
 To enable the deployment of a Jobs Service instance, the `SonataFlowPlatform` CRD exposes a set of fields that allow the user to 

--- a/serverlessworkflow/modules/ROOT/pages/cloud/operator/enabling-jobs-service.adoc
+++ b/serverlessworkflow/modules/ROOT/pages/cloud/operator/enabling-jobs-service.adoc
@@ -160,7 +160,7 @@ sonataflow-platform-jobs-service-79bb6bc67f-gvcg4   1/1     Running   0         
 
 == Conclusion
 The Operator extends its scope to manage the lifecycle of the Jobs Service instance, thus removing the burden to the users and allowing them to focus on the
-implementation of the `Sonataworkflows. It takes care of managing the Jobs Service deployment, dynamically configure its application properties
+implementation of the `Sonataworkflows. It takes care of managing the Jobs Service deployment, dynamically configures its application properties
 when the Data Index service is also available and managed by the Operator, and finally inject application properties in `SonataFlow` workflows in the target
 namespace when the Jobs Service is available.
 

--- a/serverlessworkflow/modules/ROOT/pages/cloud/operator/enabling-jobs-service.adoc
+++ b/serverlessworkflow/modules/ROOT/pages/cloud/operator/enabling-jobs-service.adoc
@@ -13,7 +13,7 @@ While it is possible to deploy the Jobs Service manually, the Operator also prov
 namespace configuration via the `SonataFlowPlatform` CR. With this approach, the Operator will take care of configuring the
 Jobs Service instance and ensure it is in sync with the specification in the CR. When the operator manages the Jobs Service lifecycle,
 it will inject properties in `SonataFlow` workflows at creation time to enable the workflows to communicate with the Jobs Service
-instance during their execution, removing the need to add these properties as part of the `SonataFlow` workflow CR instance.
+It is possible to deploy the Jobs Service manually, but the Operator also provides a convenient way to combine it with the namespace configuration via the `SonataFlowPlatform` CR. This approach allows the Operator to configure the Jobs Service and make sure it is in line with the Specification in CR. When the Operator manages the jobs service lifecycle, it injects properties at creation time in the `SonataFlow` workflows to communicate with the Jobs Service during execution, eliminating the need to include these properties in the workflow CR instance of the `SonataFlow` workflow.
 
 == Configuring Jobs Service in the SonataFlowPlatformCR
 

--- a/serverlessworkflow/modules/ROOT/pages/cloud/operator/enabling-jobs-service.adoc
+++ b/serverlessworkflow/modules/ROOT/pages/cloud/operator/enabling-jobs-service.adoc
@@ -96,7 +96,7 @@ spec:
 ...
 ---
 
-When using the `jdbcUrl` field instead of `serviceRef`, the user is responsible of providing the correct JDBC URL connection value that does not contain a `database schema`
+When using the `jdbcUrl` field instead of `serviceRef`, the user is responsible for providing the correct JDBC URL connection value that does not contain a `database schema`
 because the operator will use verbatim the contents of this field as the JDBC connection in the Jobs Service pod, and if it provides a schema that has been used or formatted 
 by a different client, the pod will fail to run.
 

--- a/serverlessworkflow/modules/ROOT/pages/cloud/operator/enabling-jobs-service.adoc
+++ b/serverlessworkflow/modules/ROOT/pages/cloud/operator/enabling-jobs-service.adoc
@@ -1,19 +1,19 @@
 = Managing Jobs Service with the Operator
 :compat-mode!:
 // Metadata:
-:description: Configure Jobs Service using the SonataFlowPlatform CR.
+:description: Configure Jobs Service using the `SonataFlowPlatform` CR.
 :keywords: sonataflow, serverless, operator, kubernetes, jobs service
 
 
 This document describes how to configure the Jobs Service instance usimg the SonataFlowPlarform CR.
 
-== Automate the Jobs Service instance management with the SonataFlow Operator
+== Automate the Jobs Service instance management with the `SonataFlow` Operator
 
 While it is possible to deploy the Jobs Service manually, the Operator also provides a convenient way to combine it with the
-namespace configuration via the SonataFlowPlatform CR. With this approach, the Operator will take care of configuring the
+namespace configuration via the `SonataFlowPlatform` CR. With this approach, the Operator will take care of configuring the
 Jobs Service instance and ensure it is in sync with the specification in the CR. When the operator manages the Jobs Service lifecycle,
-it will inject properties in SonataFlow workflows at creation time to enable the workflows to communicate with the Jobs Service
-instance during their execution, removing the need to add these properties as part of the SonataFlow workflow CR instance.
+it will inject properties in `SonataFlow` workflows at creation time to enable the workflows to communicate with the Jobs Service
+instance during their execution, removing the need to add these properties as part of the `SonataFlow` workflow CR instance.
 
 == Configuring Jobs Service in the SonataFlowPlatformCR
 
@@ -37,7 +37,7 @@ spec:
 
 When executing this manifest, the operator will reconcile generating a pod hosting the Jobs Service:
 
-[source,yaml,subs="attributes+"]
+[source,shell,subs="attributes+"]
 ---
 $>kubectl get pod -n sonataflow
 NAME                                               READY   STATUS    RESTARTS   AGE
@@ -50,8 +50,57 @@ Keep in mind that this setup is not recommended for production environments, chi
 For robust environments it is recommened to use an dedicated database service and configure Jobs Service to make use of it. Currently, the Jobs Service
 only supports PostgreSQL database.
 
-To configure Jobs Service to communicate with an existing PostgreSQL instance running in the same cluster you will need to specify the secret that contains
-the credentials to authenticate with the database, and then define the kubernetes service specification:
+Configuring Jobs Service to communicate with an existing PostgreSQL instance is supported in two ways. In both cases it requires providing the persistence
+configuration, one by using the Jobs Service's persistence field and the other one using the persistence field defined in the `SonataFlowPlatform` CR
+deployed in the same namespace.
+
+By default, the persistence specification defined in the `SonataFlow` workflow's CR takes precedence over the one in the `SonataFlowPlatform` persistence's specification.
+
+===== Using the persistence field defined in the `SonataFlowPlatform` CR
+Using the persistence configuration in the `SonataFlowPlatform` CR located in the same namespace requires to have the `SonataFlow` CR persistence field configured
+to have an empty `{}` value, signaling the Operator to derive the persistence from the active `SonataFlowPlatform`, when available. If no persistence is defined
+the operator will fallback to the ephemeral persistence previously described.
+
+[source,yaml,subs="attributes+"]
+---
+apiVersion: sonataflow.org/v1alpha08
+kind: SonataFlowPlatform
+metadata:
+  name: sonataflow-platform
+spec:
+  persistence:
+    postgresql:
+      secretRef:
+        name: postgres-secrets
+        userKey: POSTGRES_USER
+        passwordKey: POSTGRES_PASSWORD
+      serviceRef:
+        name: postgres
+        port: 5432
+        databaseName: sonataflow
+---
+
+And the `SonataFlow` CR looks like this:
+
+[source,yaml,subs="attributes+"]
+---
+apiVersion: sonataflow.org/v1alpha08
+kind: SonataFlow
+metadata:
+  name: callbackstatetimeouts
+  annotations:
+    sonataflow.org/description: Callback State Timeouts Example k8s
+    sonataflow.org/version: 0.0.1
+spec:
+  persistence: {}
+...
+---
+
+When the database schema is not defined in the persistence configuration, the operator will generate the schema and use the workflow's given name instead.
+
+===== Using the persistency field inside the service specification
+You can specify define the persistence configuration directly in the Jobs Service specification. The structure is the same as in the `SonataFlowPlatform` CR and also
+consist on the credentials to access the PostgreSQL instance, and the kubernetes service reference to generate the connectivity.
 
 [source,yaml,subs="attributes+"]
 ---
@@ -79,7 +128,7 @@ if it doesn't exist.
 
 The values of `POSTGRES_USER` and `POSTGRES_PASSWORD` point to the keys in the secret that contains the PostgreSQL credentials.
 
-[source,yaml,subs="attributes+"]
+[source,shell,subs="attributes+"]
 ---
 $>kubectl describe secrets postgres-secrets
 Name:         postgres-secrets
@@ -99,7 +148,7 @@ POSTGRES_USER:      10 bytes
 
 Putting everything together will render an output similar to this one below:
 
-[source,yaml,subs="attributes+"]
+[source,shell,subs="attributes+"]
 ---
 $>kubectl get pod -w -n sonataflow
 NAME                                                READY   STATUS    RESTARTS   AGE
@@ -109,8 +158,8 @@ sonataflow-platform-jobs-service-79bb6bc67f-gvcg4   1/1     Running   0         
 
 == Conclusion
 The Operator extends its scope to manage the lifecycle of the Jobs Service instance, thus removing the burden to the users and allowing them to focus on the
-implementation of the SonataFlow workflows. It takes care of managing the Jobs Service deployment, dynamically configure its application properties
-when the Data Index service is also available and managed by the Operator, and finally inject application properties in SonataFlow workflows in the target
+implementation of the `Sonataworkflows. It takes care of managing the Jobs Service deployment, dynamically configure its application properties
+when the Data Index service is also available and managed by the Operator, and finally inject application properties in `SonataFlow` workflows in the target
 namespace when the Jobs Service is available.
 
 == Additional resources

--- a/serverlessworkflow/modules/ROOT/pages/cloud/operator/enabling-jobs-service.adoc
+++ b/serverlessworkflow/modules/ROOT/pages/cloud/operator/enabling-jobs-service.adoc
@@ -96,7 +96,9 @@ spec:
 ...
 ---
 
-When the database schema is not defined in the persistence configuration, the operator will generate the schema and use the workflow's given name instead.
+When using the `jdbcUrl` field instead of `serviceRef`, the user is responsible of providing the correct JDBC URL connection value that does not contain a `database schema`
+because the operator will use verbatim the contents of this field as the JDBC connection in the Jobs Service pod, and if it provides a schema that has been used or formatted 
+by a different client, the pod will fail to run.
 
 ===== Using the persistency field inside the service specification
 You can specify define the persistence configuration directly in the Jobs Service specification. The structure is the same as in the `SonataFlowPlatform` CR and also

--- a/serverlessworkflow/modules/ROOT/pages/cloud/operator/enabling-jobs-service.adoc
+++ b/serverlessworkflow/modules/ROOT/pages/cloud/operator/enabling-jobs-service.adoc
@@ -47,7 +47,7 @@ sonataflow-platform-jobs-service-cdf85d969-sbwkj   1/1     Running   0          
 Keep in mind that this setup is not recommended for production environments, especially because the data does not persist when the pod restarts.
 
 ==== Using an existing postgreSQL service
-For robust environments it is recommened to use an dedicated database service and configure Jobs Service to make use of it. Currently, the Jobs Service
+For robust environments, it is recommended to use a dedicated database service and configure Jobs Service to make use of it. Currently, the Jobs Service
 only supports PostgreSQL database.
 
 Configuring Jobs Service to communicate with an existing PostgreSQL instance is supported in two ways. In both cases it requires providing the persistence

--- a/serverlessworkflow/modules/ROOT/pages/cloud/operator/enabling-jobs-service.adoc
+++ b/serverlessworkflow/modules/ROOT/pages/cloud/operator/enabling-jobs-service.adoc
@@ -18,7 +18,7 @@ This integration eliminates the need for including these properties within the S
 To enable the deployment of a Jobs Service instance, the `SonataFlowPlatform` CRD exposes a set of fields that allow the user to 
 configure the running instance. 
 
-==== Ephemeral persistence
+=== Ephemeral persistence
 The basic runtime is to deploy the Jobs Service with an ephemeral backend running in the same container
 as the Jobs Service runtime.
 
@@ -44,7 +44,7 @@ sonataflow-platform-jobs-service-cdf85d969-sbwkj   1/1     Running   0          
 
 Keep in mind that this setup is not recommended for production environments, especially because the data does not persist when the pod restarts.
 
-==== Using an existing PostgreSQL service
+=== Using an existing PostgreSQL service
 For robust environments it is recommened to use an dedicated database service and configure Jobs Service to make use of it. Currently, the Jobs Service
 only supports PostgreSQL database.
 
@@ -54,7 +54,7 @@ deployed in the same namespace.
 
 By default, the persistence specification defined in the `SonataFlow` workflow's CR takes priority over the one in the `SonataFlowPlatform` persistence specification.
 
-===== Using the persistence field defined in the `SonataFlowPlatform` CR
+==== Using the persistence field defined in the `SonataFlowPlatform` CR
 Using the persistence configuration in the `SonataFlowPlatform` CR located in the same namespace requires to have the `SonataFlow` CR persistence field configured
 to have an empty `{}` value, signaling the Operator to derive the persistence from the active `SonataFlowPlatform`, when available. If no persistence is defined
 the operator will fallback to the ephemeral persistence previously described.
@@ -139,7 +139,7 @@ Annotations:  <none>
 Type:  Opaque
 
 Data
-====
+\\\\====
 PGDATA:             28 bytes
 POSTGRES_DATABASE:  10 bytes
 POSTGRES_PASSWORD:  10 bytes

--- a/serverlessworkflow/modules/ROOT/pages/cloud/operator/enabling-jobs-service.adoc
+++ b/serverlessworkflow/modules/ROOT/pages/cloud/operator/enabling-jobs-service.adoc
@@ -54,7 +54,7 @@ Configuring Jobs Service to communicate with an existing PostgreSQL instance is 
 configuration, one by using the Jobs Service's persistence field and the other one using the persistence field defined in the `SonataFlowPlatform` CR
 deployed in the same namespace.
 
-By default, the persistence specification defined in the `SonataFlow` workflow's CR takes precedence over the one in the `SonataFlowPlatform` persistence's specification.
+By default, the persistence specification defined in the `SonataFlow` workflow's CR takes priority over the one in the `SonataFlowPlatform` persistence specification.
 
 ===== Using the persistence field defined in the `SonataFlowPlatform` CR
 Using the persistence configuration in the `SonataFlowPlatform` CR located in the same namespace requires to have the `SonataFlow` CR persistence field configured

--- a/serverlessworkflow/modules/ROOT/pages/cloud/operator/enabling-jobs-service.adoc
+++ b/serverlessworkflow/modules/ROOT/pages/cloud/operator/enabling-jobs-service.adoc
@@ -101,7 +101,7 @@ because the operator will use verbatim the contents of this field as the JDBC co
 by a different client, the pod will fail to run.
 
 ===== Using the persistency field inside the service specification
-You can specify define the persistence configuration directly in the Jobs Service specification. The structure is the same as in the `SonataFlowPlatform` CR and also
+You can specify and define the persistence configuration directly in the Jobs Service specification. The structure is the same as in the `SonataFlowPlatform` CR and also
 consist on the credentials to access the PostgreSQL instance, and the kubernetes service reference to generate the connectivity.
 
 [source,yaml,subs="attributes+"]

--- a/serverlessworkflow/modules/ROOT/pages/cloud/operator/enabling-jobs-service.adoc
+++ b/serverlessworkflow/modules/ROOT/pages/cloud/operator/enabling-jobs-service.adoc
@@ -5,7 +5,7 @@
 :keywords: sonataflow, serverless, operator, kubernetes, jobs service
 
 
-This document describes how to configure the Jobs Service instance usimg the SonataFlowPlarform CR.
+This document describes how to configure the Jobs Service instance using the SonataFlowPlarform CR.
 
 == Automate the Jobs Service instance management with the `SonataFlow` Operator
 
@@ -15,7 +15,7 @@ Jobs Service instance and ensure it is in sync with the specification in the CR.
 it will inject properties in `SonataFlow` workflows at creation time to enable the workflows to communicate with the Jobs Service
 It is possible to deploy the Jobs Service manually, but the Operator also provides a convenient way to combine it with the namespace configuration via the `SonataFlowPlatform` CR. This approach allows the Operator to configure the Jobs Service and make sure it is in line with the Specification in CR. When the Operator manages the jobs service lifecycle, it injects properties at creation time in the `SonataFlow` workflows to communicate with the Jobs Service during execution, eliminating the need to include these properties in the workflow CR instance of the `SonataFlow` workflow.
 
-== Configuring Jobs Service in the SonataFlowPlatformCR
+== Configuring Jobs Service in the SonataFlowPlatform CR
 
 To enable the deployment of a Jobs Service instance, the `SonataFlowPlatform` CRD exposes a set of fields that allow the user to 
 configure the running instance. 
@@ -46,8 +46,8 @@ sonataflow-platform-jobs-service-cdf85d969-sbwkj   1/1     Running   0          
 
 Keep in mind that this setup is not recommended for production environments, especially because the data does not persist when the pod restarts.
 
-==== Using an existing postgreSQL service
-For robust environments, it is recommended to use a dedicated database service and configure Jobs Service to make use of it. Currently, the Jobs Service
+==== Using an existing PostgreSQL service
+For robust environments it is recommened to use an dedicated database service and configure Jobs Service to make use of it. Currently, the Jobs Service
 only supports PostgreSQL database.
 
 Configuring Jobs Service to communicate with an existing PostgreSQL instance is supported in two ways. In both cases it requires providing the persistence
@@ -100,14 +100,14 @@ When using the `jdbcUrl` field instead of `serviceRef`, the user is responsible 
 because the operator will use verbatim the contents of this field as the JDBC connection in the Jobs Service pod, and if it provides a schema that has been used or formatted 
 by a different client, the pod will fail to run.
 
-===== Using the persistency field inside the service specification
-You can specify and define the persistence configuration directly in the Jobs Service specification. The structure is the same as in the `SonataFlowPlatform` CR and also
-consist of the credentials to access the PostgreSQL instance, and the kubernetes service reference to generate the connectivity.
+===== Using the persistence field inside the service specification
+You can specify define the persistence configuration directly in the Jobs Service specification. The structure is the same as in the `SonataFlowPlatform` CR and also
+consist on the credentials to access the PostgreSQL instance, and the kubernetes service reference to generate the connectivity.
 
 [source,yaml,subs="attributes+"]
 ---
 apiVersion: sonataflow.org/v1alpha08
-kind: SonataFlow
+kind: SonataFlowPlatform
 metadata:
   name: callbackstatetimeouts
 spec:

--- a/serverlessworkflow/modules/ROOT/pages/cloud/operator/enabling-jobs-service.adoc
+++ b/serverlessworkflow/modules/ROOT/pages/cloud/operator/enabling-jobs-service.adoc
@@ -159,7 +159,7 @@ sonataflow-platform-jobs-service-79bb6bc67f-gvcg4   1/1     Running   0         
 ---
 
 == Conclusion
-The Operator extends its scope to manage the lifecycle of the Jobs Service instance, thus removing the burden to the users and allowing them to focus on the
+The Operator extends its scope to manage the lifecycle of the Jobs Service instance, thus removing the burden on the users and allowing them to focus on the
 implementation of the `Sonataworkflows. It takes care of managing the Jobs Service deployment, dynamically configures its application properties
 when the Data Index service is also available and managed by the Operator, and finally inject application properties in `SonataFlow` workflows in the target
 namespace when the Jobs Service is available.

--- a/serverlessworkflow/modules/ROOT/pages/cloud/operator/enabling-jobs-service.adoc
+++ b/serverlessworkflow/modules/ROOT/pages/cloud/operator/enabling-jobs-service.adoc
@@ -102,7 +102,7 @@ by a different client, the pod will fail to run.
 
 ===== Using the persistency field inside the service specification
 You can specify and define the persistence configuration directly in the Jobs Service specification. The structure is the same as in the `SonataFlowPlatform` CR and also
-consist on the credentials to access the PostgreSQL instance, and the kubernetes service reference to generate the connectivity.
+consist of the credentials to access the PostgreSQL instance, and the kubernetes service reference to generate the connectivity.
 
 [source,yaml,subs="attributes+"]
 ---

--- a/serverlessworkflow/modules/ROOT/pages/cloud/operator/install-serverless-operator.adoc
+++ b/serverlessworkflow/modules/ROOT/pages/cloud/operator/install-serverless-operator.adoc
@@ -164,5 +164,6 @@ The URL should be the same used when installing the operator.
 
 * xref:cloud/operator/known-issues.adoc[]
 * xref:cloud/operator/developing-workflows.adoc[]
+* xref:cloud/operator/enabling-jobs-service.adoc[]
 
 include::../../../pages/_common-content/report-issue.adoc[]


### PR DESCRIPTION
Extends the documentation to include how to configure Jobs Service using the Operator.

@ricardozanini @kaldesai PTAL
