### PR TITLE
Remove push action from build action / verify preview run

### DIFF
--- a/.github/workflows/pr-preview-build.yml
+++ b/.github/workflows/pr-preview-build.yml
@@ -20,14 +20,6 @@
 name: SonataFlow Guides Preview - Build
 
 on:
-  push:
-    branches:
-        - "main"
-    paths-ignore:
-      - ".gitignore"
-      - "LICENSE"
-      - "README*"
-      - "CONTRIBUTING.md"
   pull_request:
     paths-ignore:
       - ".gitignore"

--- a/.github/workflows/pr-preview-publish.yml
+++ b/.github/workflows/pr-preview-publish.yml
@@ -35,6 +35,7 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: site
+          github_token: ${{ secrets.GITHUB_TOKEN }}
           run-id: ${{ github.event.workflow_run.workflow_id }}
 
       - name: Publish to Surge for preview


### PR DESCRIPTION
<!-- Please don't forget your Issue link -->
Closes/Fixes/Resolves #ISSUE-NUMBER

<!-- Please provide a short description of what this PR does -->
**Description:**
Small PR to verify if the preview actions are working and fixing it.

<!-- Link to related PRs: -->
Relates to #539 

Please make sure that your PR meets the following requirements:


- [ ] You have read the [contributions doc](https://github.com/apache/incubator-kie-kogito-docs/blob/main/CONTRIBUTING.md)
- [ ] Pull Request title is properly formatted: `Issue-XYZ Subject`
- [ ] Pull Request title contains the target branch if not targeting main: `[0.9.x] Issue-XYZ Subject`
- [ ] The nav.adoc file has a link to this guide in the proper category
- [ ] The index.adoc file has a card to this guide in the proper category, with a meaningful description

<details>
<summary>
How to backport a pull request to a different branch?
</summary>

In order to automatically create a **backporting pull request** please add one or more labels having the following format `backport-<branch-name>`, where `<branch-name>` is the name of the branch where the pull request must be backported to (e.g., `backport-7.67.x` to backport the original PR to the `7.67.x` branch).

> **NOTE**: **backporting** is an action aiming to move a change (usually a commit) from a branch (usually the main one) to another one, which is generally referring to a still maintained release branch. Keeping it simple: it is about to move a specific change or a set of them from one branch to another.

Once the original pull request is successfully merged, the automated action will create one backporting pull request per each label (with the previous format) that has been added.

If something goes wrong, the author will be notified and at this point a manual backporting is needed.

> **NOTE**: this automated backporting is triggered whenever a pull request on `main` branch is labeled or closed, but both conditions must be satisfied to get the new PR created.
</details>