### PR TITLE
Fix path and run-id event for surge.sh preview workflows

### DIFF
--- a/.github/workflows/pr-preview-publish.yml
+++ b/.github/workflows/pr-preview-publish.yml
@@ -36,7 +36,8 @@ jobs:
         with:
           name: site
           github-token: ${{ secrets.GITHUB_TOKEN }}
-          run-id: ${{ github.event.workflow_run.workflow_id }}
+          run-id: ${{ github.event.workflow_run.id }}
+          path: ./build/site
 
       - name: Publish to Surge for preview
         id: deploy


### PR DESCRIPTION
Quick fix for the following error:

```log
##[debug]Evaluating condition for step: 'Download PR Artifact'
##[debug]Evaluating: success()
##[debug]Evaluating success:
##[debug]=> true
##[debug]Result: true
##[debug]Starting: Download PR Artifact
##[debug]Loading inputs
##[debug]Evaluating: secrets.GITHUB_TOKEN
##[debug]Evaluating Index:
##[debug]..Evaluating secrets:
##[debug]..=> Object
##[debug]..Evaluating String:
##[debug]..=> 'GITHUB_TOKEN'
##[debug]=> '***'
##[debug]Result: '***'
##[debug]Evaluating: github.event.workflow_run.workflow_id
##[debug]Evaluating Index:
##[debug]..Evaluating Index:
##[debug]....Evaluating Index:
##[debug]......Evaluating github:
##[debug]......=> Object
##[debug]......Evaluating String:
##[debug]......=> 'event'
##[debug]....=> Object
##[debug]....Evaluating String:
##[debug]....=> 'workflow_run'
##[debug]..=> Object
##[debug]..Evaluating String:
##[debug]..=> 'workflow_id'
##[debug]=> 88646199
##[debug]Result: 88646199
##[debug]Evaluating: github.repository
##[debug]Evaluating Index:
##[debug]..Evaluating github:
##[debug]..=> Object
##[debug]..Evaluating String:
##[debug]..=> 'repository'
##[debug]=> 'apache/incubator-kie-kogito-docs'
##[debug]Result: 'apache/incubator-kie-kogito-docs'
##[debug]Loading env
Run actions/download-artifact@v4
  with:
    name: site
    github-token: ***
    run-id: 88646199
    merge-multiple: false
    repository: apache/incubator-kie-kogito-docs
##[debug]Resolved path is /home/runner/work/incubator-kie-kogito-docs/incubator-kie-kogito-docs
Downloading single artifact
##[debug]GitHub client configured with: (retries: 5, retry-exempt-status-code: 400,401,403,404,4[2](https://github.com/apache/incubator-kie-kogito-docs/actions/runs/8178630529/job/22390851449#step:2:2)2)
Error: Unable to download artifact(s): Not Found
##[debug]Node Action run completed with exit code 1
##[debug]Finishing: Download PR Artifact
```