### PR TITLE
Add PR id to publish workflows

### DIFF
--- a/.github/workflows/pr-preview-publish.yml
+++ b/.github/workflows/pr-preview-publish.yml
@@ -41,7 +41,7 @@ jobs:
 
       - name: Publish to Surge for preview
         id: deploy
-        run: npx surge ./build/site --domain https://sonataflow-docs-preview-pr-${{ github.event.number }}.surge.sh --token ${{ secrets.SURGE_LOCAL_TOKEN }}
+        run: npx surge ./build/site --domain https://sonataflow-docs-preview-pr-${{ github.event.workflow_run.pull_requests[0].number }}.surge.sh --token ${{ secrets.SURGE_LOCAL_TOKEN }}
 
       - name: Update PR status comment on success
         if: success()
@@ -49,10 +49,10 @@ jobs:
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           body: |
-            🎊 PR Preview ${{ github.sha }} has been successfully built and deployed. See the documentation preview: https://sonataflow-docs-preview-pr-${{ github.event.number }}.surge.sh
+            🎊 PR Preview ${{ github.sha }} has been successfully built and deployed. See the documentation preview: https://sonataflow-docs-preview-pr-${{ github.event.workflow_run.pull_requests[0].number }}.surge.sh
             <!-- Sticky Pull Request Comment -->
           body-include: "<!-- Sticky Pull Request Comment -->"
-          number: ${{ github.event.number }}
+          number: ${{ github.event.workflow_run.pull_requests[0].number }}
           emojis: "heart"
 
       - name: Update PR status comment on failure
@@ -65,5 +65,5 @@ jobs:
             <img width="300" src="https://user-images.githubusercontent.com/507615/90250824-4e066700-de6f-11ea-8230-600ecc3d6a6b.png">
             <!-- Sticky Pull Request Comment -->
           body-include: "<!-- Sticky Pull Request Comment -->"
-          number: ${{ github.event.number }}
+          number: ${{ github.event.workflow_run.pull_requests[0].number }}
           emojis: "confused"


### PR DESCRIPTION
Another quick one to fix this:

```
Run actions-cool/maintain-one-comment@v3
  with:
    token: ***
    body: 🎊 PR Preview caf86c86[2](https://github.com/apache/incubator-kie-kogito-docs/actions/runs/8189571112/job/22394610894#step:4:2)ff0c5b020f2[4](https://github.com/apache/incubator-kie-kogito-docs/actions/runs/8189571112/job/22394610894#step:4:4)8d40d89[5](https://github.com/apache/incubator-kie-kogito-docs/actions/runs/8189571112/job/22394610894#step:4:5)d0d4a817b9d has been successfully built and deployed. See the documentation preview: https://sonataflow-docs-preview-pr-.surge.sh
  <!-- Sticky Pull Request Comment -->
  
    body-include: <!-- Sticky Pull Request Comment -->
    emojis: heart
Now eventName: workflow_run. And input number is empty. This Action only support issue and pull_request related!
```

See https://github.com/apache/incubator-kie-kogito-docs/actions/runs/8189571112/job/22394610894