### PR TITLE
NO-ISSUE - Try to fix PR id not found in github event

### DIFF
--- a/.github/workflows/pr-preview-publish.yml
+++ b/.github/workflows/pr-preview-publish.yml
@@ -31,6 +31,14 @@ jobs:
     if: github.event.workflow_run.event == 'pull_request' && github.event.workflow_run.conclusion == 'success'
     runs-on: ubuntu-latest
     steps:
+      - name: Get PR number
+        id: get_pr_number
+        run: |
+          PR_URL=$(curl -s -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" ${{ github.event.workflow_run.url }}/pull_requests | jq -r '.pull_requests[0].url')
+          PR_NUMBER=$(basename $PR_URL)
+          echo "PR number: $PR_NUMBER"
+        shell: bash
+
       - name: Download PR Artifact
         uses: actions/download-artifact@v4
         with:
@@ -41,7 +49,7 @@ jobs:
 
       - name: Publish to Surge for preview
         id: deploy
-        run: npx surge ./build/site --domain https://sonataflow-docs-preview-pr-${{ github.event.workflow_run.pull_requests[0].number }}.surge.sh --token ${{ secrets.SURGE_LOCAL_TOKEN }}
+        run: npx surge ./build/site --domain https://sonataflow-docs-preview-pr-${{ env.PR_NUMBER }}.surge.sh --token ${{ secrets.SURGE_LOCAL_TOKEN }}
 
       - name: Update PR status comment on success
         if: success()
@@ -49,10 +57,10 @@ jobs:
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           body: |
-            🎊 PR Preview ${{ github.sha }} has been successfully built and deployed. See the documentation preview: https://sonataflow-docs-preview-pr-${{ github.event.workflow_run.pull_requests[0].number }}.surge.sh
+            🎊 PR Preview ${{ github.sha }} has been successfully built and deployed. See the documentation preview: https://sonataflow-docs-preview-pr-${{ env.PR_NUMBER }}.surge.sh
             <!-- Sticky Pull Request Comment -->
           body-include: "<!-- Sticky Pull Request Comment -->"
-          number: ${{ github.event.workflow_run.pull_requests[0].number }}
+          number: ${{ env.PR_NUMBER }}
           emojis: "heart"
 
       - name: Update PR status comment on failure
@@ -65,5 +73,5 @@ jobs:
             <img width="300" src="https://user-images.githubusercontent.com/507615/90250824-4e066700-de6f-11ea-8230-600ecc3d6a6b.png">
             <!-- Sticky Pull Request Comment -->
           body-include: "<!-- Sticky Pull Request Comment -->"
-          number: ${{ github.event.workflow_run.pull_requests[0].number }}
+          number: ${{ env.PR_NUMBER }}
           emojis: "confused"


### PR DESCRIPTION
Since we have a problem in the GitHub Actions ecosystem, we need a way to grab the PR ids. See more: https://github.com/orgs/community/discussions/25220