### PR TITLE
kie-kogito-docs-528: Document timeout format limitation

### DIFF
--- a/serverlessworkflow/modules/ROOT/pages/core/timeouts-support.adoc
+++ b/serverlessworkflow/modules/ROOT/pages/core/timeouts-support.adoc
@@ -10,6 +10,11 @@ For example, you can configure how long a workflow can wait for an event to arri
 Regardless of its application scope (workflow or state), the timeouts must be configured as an amount of time (a duration), which is considered to start when the referred scope becomes active. Timeouts use the link:https://en.wikipedia.org/wiki/ISO_8601[`ISO 8601` data and time standard] to specify a duration of time and follow the format `PnDTnHnMn.nS` with days considered to be exactly 24 hours.
 For instance, `PT15M` configures 15 minutes, and `P2DT3H4M` defines 2 days, 3 hours and 4 minutes.
 
+[NOTE]
+====
+Month based timeouts like P2M (period of two months) are not valid since the month duration might vary. In that case you can use PT60D instead.
+====
+
 [#workflow-timeout]
 == Workflow timeout 
 To configure the maximum amount of time a workflow can be running before being canceled, you can use the workflow timeout.


### PR DESCRIPTION
<!-- Please don't forget your Issue link -->
Closes/Fixes/Resolves #528 

<!-- Please provide a short description of what this PR does -->
**Description:**

<!-- Link to related PRs: -->

Please make sure that your PR meets the following requirements:

- [X] You have read the [contributions doc](https://github.com/apache/incubator-kie-kogito-docs/blob/main/CONTRIBUTING.md)
- [X] Pull Request title is properly formatted: `Issue-XYZ Subject`
- [X] Pull Request title contains the target branch if not targeting main: `[0.9.x] Issue-XYZ Subject`
- [X] The nav.adoc file has a link to this guide in the proper category
- [X] The index.adoc file has a card to this guide in the proper category, with a meaningful description

<details>
<summary>
How to backport a pull request to a different branch?
</summary>

In order to automatically create a **backporting pull request** please add one or more labels having the following format `backport-<branch-name>`, where `<branch-name>` is the name of the branch where the pull request must be backported to (e.g., `backport-7.67.x` to backport the original PR to the `7.67.x` branch).

> **NOTE**: **backporting** is an action aiming to move a change (usually a commit) from a branch (usually the main one) to another one, which is generally referring to a still maintained release branch. Keeping it simple: it is about to move a specific change or a set of them from one branch to another.

Once the original pull request is successfully merged, the automated action will create one backporting pull request per each label (with the previous format) that has been added.

If something goes wrong, the author will be notified and at this point a manual backporting is needed.

> **NOTE**: this automated backporting is triggered whenever a pull request on `main` branch is labeled or closed, but both conditions must be satisfied to get the new PR created.
</details>