### PR TITLE
Fixing typo on Python guide

### DIFF
--- a/serverlessworkflow/modules/ROOT/pages/use-cases/advanced-developer-use-cases/integrations/custom-functions-python.adoc
+++ b/serverlessworkflow/modules/ROOT/pages/use-cases/advanced-developer-use-cases/integrations/custom-functions-python.adoc
@@ -8,7 +8,7 @@ This document describes how to integrate python scripts and functions into your 
 
 == Enable Python support
 
- To enable Python support, you must add the Python add-on dependency to your {prouct_name} module `pom.xml` file
+To enable Python support, you must add the Python add-on dependency to your {product_name} module `pom.xml` file
 
 [source,xml]
 ----


### PR DESCRIPTION
Fixing typo on Python guide