### PR TITLE
Replace kogito-examples with incubator-kie-kogito-examples

### DIFF
--- a/serverlessworkflow/antora.yml
+++ b/serverlessworkflow/antora.yml
@@ -49,6 +49,7 @@ asciidoc:
     sonataflow_devmode_devui_url: /q/dev/org.kie.kogito.kogito-quarkus-serverless-workflow-devui/
     serverless_logic_web_tools_name: Serverless Logic Web Tools
     serverless_workflow_vscode_extension_name: KIE Serverless Workflow Editor
+    kie_kogito_examples_repo_name: incubator-kie-kogito-examples
 
     #
     #  Versions 

--- a/serverlessworkflow/modules/ROOT/pages/security/orchestrating-third-party-services-with-oauth2.adoc
+++ b/serverlessworkflow/modules/ROOT/pages/security/orchestrating-third-party-services-with-oauth2.adoc
@@ -42,7 +42,7 @@ When you use the Acme Financial Services, you can query the exchange rates using
 * Potential vendor lock-in problems, in case you want to change the provider in the future.
 * Domain-specific validations and optimizations.
 
-The further sections describes how an end-to-end solution is created in the `serverless-workflow-oauth2-orchestration-quarkus` example application. To see the source code of `serverless-workflow-oauth2-orchestration-quarkus` example application, you can clone the link:{kogito_examples_repository_url}[kogito-examples] repository in GitHub and select the `serverless-workflow-examples/serverless-workflow-oauth2-orchestration-quarkus` directory.
+The further sections describes how an end-to-end solution is created in the `serverless-workflow-oauth2-orchestration-quarkus` example application. To see the source code of `serverless-workflow-oauth2-orchestration-quarkus` example application, you can clone the link:{kogito_examples_repository_url}[{kie_kogito_examples_repo_name}] repository in GitHub and select the `serverless-workflow-examples/serverless-workflow-oauth2-orchestration-quarkus` directory.
 
 The `serverless-workflow-oauth2-orchestration-quarkus` example application contains the following services to compose the solution:
 
@@ -463,15 +463,16 @@ Once you clone the `serverless-workflow-oauth2-orchestration-quarkus` example ap
 
 
 .Procedure
-. In a command terminal, clone the `kogito-examples` repository and navigate to the cloned directory:
+. In a command terminal, clone the `{kie_kogito_examples_repo_name}` repository and navigate to the cloned directory:
 +
 --
-.Clone `kogito-examples` repository and navigate to the directory
-[source, bash]
-----
-git clone https://github.com/apache/incubator-kie-kogito-examples.git
+.Clone `{kie_kogito_examples_repo_name}` repository and navigate to the directory
 
-cd kogito-examples/serverless-workflow-examples/serverless-workflow-oauth2-orchestration-quarkus
+[source,bash,subs="attributes+"]
+----
+git clone {kogito_examples_url}
+
+cd {kie_kogito_examples_repo_name}/serverless-workflow-examples/serverless-workflow-oauth2-orchestration-quarkus
 ----
 --
 
@@ -491,7 +492,7 @@ mvn clean install
 .Start the Keycloak server
 [source, bash]
 ----
-cd kogito-examples/serverless-workflow-examples/serverless-workflow-oauth2-orchestration-quarkus/scripts
+cd {kie_kogito_examples_repo_name}/serverless-workflow-examples/serverless-workflow-oauth2-orchestration-quarkus/scripts
 
 ./startKeycloak.sh
 ----
@@ -501,7 +502,7 @@ Alternatively, you can start the Docker Compose using the following command:
 .Start Docker Compose
 [source, bash]
 ----
-cd kogito-examples/serverless-workflow-examples/serverless-workflow-oauth2-orchestration-quarkus/docker-compose
+cd {kie_kogito_examples_repo_name}/serverless-workflow-examples/serverless-workflow-oauth2-orchestration-quarkus/docker-compose
 
 docker-compose up
 ----
@@ -513,7 +514,7 @@ docker-compose up
 .Start Acme Financial Service
 [source, bash]
 ----
-cd kogito-examples/serverless-workflow-examples/serverless-workflow-oauth2-orchestration-quarkus/acme-financial-service
+cd {kie_kogito_examples_repo_name}/serverless-workflow-examples/serverless-workflow-oauth2-orchestration-quarkus/acme-financial-service
 
 java -jar target/quarkus-app/quarkus-run.jar
 ----
@@ -525,7 +526,7 @@ java -jar target/quarkus-app/quarkus-run.jar
 .Start currency exchange workflow
 [source, bash]
 ----
-cd kogito-examples/serverless-workflow-examples/serverless-workflow-oauth2-orchestration-quarkus/currency-exchange-workflow
+cd {kie_kogito_examples_repo_name}/serverless-workflow-examples/serverless-workflow-oauth2-orchestration-quarkus/currency-exchange-workflow
 
 java -jar target/quarkus-app/quarkus-run.jar
 ----

--- a/serverlessworkflow/modules/ROOT/pages/use-cases/advanced-developer-use-cases/deployments/common/_proc_deploy_sw_quarkus_cli.adoc
+++ b/serverlessworkflow/modules/ROOT/pages/use-cases/advanced-developer-use-cases/deployments/common/_proc_deploy_sw_quarkus_cli.adoc
@@ -57,7 +57,7 @@ quarkus build -DskipTests
 
 [NOTE]
 ====
-The `kogito-examples` already have this extension added by default, and can be activated with the `container` Maven profile.
+The `{kie_kogito_examples_repo_name}` already have this extension added by default, and can be activated with the `container` Maven profile.
 ====
 
 // verify deployed swf

--- a/serverlessworkflow/modules/ROOT/pages/use-cases/advanced-developer-use-cases/event-orchestration/newsletter-subscription-example.adoc
+++ b/serverlessworkflow/modules/ROOT/pages/use-cases/advanced-developer-use-cases/event-orchestration/newsletter-subscription-example.adoc
@@ -216,13 +216,13 @@ image::use-cases/newsletter-subscription/newsletter-subscription-backend-ui.png[
 
 == Executing the workflows
 
-In a command terminal, clone the `kogito-examples` repository, navigate to the cloned directory, and follow link:{kogito_sw_examples_url}/serverless-workflow-newsletter-subscription/README.md#running-on-knative[these steps]:
+In a command terminal, clone the `{kie_kogito_examples_repo_name}` repository, navigate to the cloned directory, and follow link:{kogito_sw_examples_url}/serverless-workflow-newsletter-subscription/README.md#running-on-knative[these steps]:
 
-[source, bash]
+[source,bash,subs="attributes+"]
 ----
-git clone https://github.com/apache/incubator-kie-kogito-examples.git
+git clone {kogito_examples_url}
 
-cd kogito-examples/serverless-workflow-examples/serverless-workflow-newsletter-subscription
+cd {kie_kogito_examples_repo_name}/serverless-workflow-examples/serverless-workflow-newsletter-subscription
 ----
 
 === Architecture

--- a/serverlessworkflow/modules/ROOT/pages/use-cases/advanced-developer-use-cases/getting-started/build-workflow-image-with-quarkus-cli.adoc
+++ b/serverlessworkflow/modules/ROOT/pages/use-cases/advanced-developer-use-cases/getting-started/build-workflow-image-with-quarkus-cli.adoc
@@ -7,7 +7,6 @@
 :quarkus_container_images_url: https://quarkus.io/guides/container-image
 :quarkus_native_builds_url: https://quarkus.io/guides/building-native-image
 :google_jib_url: https://github.com/GoogleContainerTools/jib
-:kogito_sw_examples_git_repo_url: https://github.com/apache/incubator-kie-kogito-examples.git
 
 This document describes how to build a {product_name} container image using the link:{quarkus_cli_url}[Quarkus CLI].
 

--- a/serverlessworkflow/modules/ROOT/pages/use-cases/advanced-developer-use-cases/getting-started/working-with-serverless-workflow-quarkus-examples.adoc
+++ b/serverlessworkflow/modules/ROOT/pages/use-cases/advanced-developer-use-cases/getting-started/working-with-serverless-workflow-quarkus-examples.adoc
@@ -7,7 +7,6 @@
 :quarkus_container_images_url: https://quarkus.io/guides/container-image
 :quarkus_native_builds_url: https://quarkus.io/guides/building-native-image
 :google_jib_url: https://github.com/GoogleContainerTools/jib
-:kogito_sw_examples_git_repo_url: https://github.com/apache/incubator-kie-kogito-examples.git
 
 This document describes how to work with {product_name} example applications.
 
@@ -21,13 +20,13 @@ To get started with our examples, you can use the link:{kogito_sw_examples_url}/
 However, same procedure can be applied to any example located in link:{kogito_sw_examples_url}[{product_name} example repository].
 
 .Procedure
-. Clone the link:{kogito_sw_examples_git_repo_url}[kogito-examples] repository and navigate to the link:{kogito_sw_examples_url}/serverless-workflow-greeting-quarkus[`serverless-workflow-greeting-quarkus`] example application.
+. Clone the link:{kogito_examples_url}[{kie_kogito_examples_repo_name}] repository and navigate to the link:{kogito_sw_examples_url}/serverless-workflow-greeting-quarkus[`serverless-workflow-greeting-quarkus`] example application.
 +
 .Clone an example application
 [source,shell,subs="attributes+"]
 ----
-git clone --branch main {kogito_sw_examples_git_repo_url} 
-cd incubator-kie-kogito-examples/serverless-workflow-examples/serverless-workflow-greeting-quarkus
+git clone --branch main {kogito_examples_url}
+cd {kie_kogito_examples_repo_name}/serverless-workflow-examples/serverless-workflow-greeting-quarkus
 ----
 
 . To run the example application, follow the instructions located in the README.md. Every example provides a file with instructions on how to run and work with it.

--- a/serverlessworkflow/modules/ROOT/pages/use-cases/advanced-developer-use-cases/persistence/persistence-with-postgresql.adoc
+++ b/serverlessworkflow/modules/ROOT/pages/use-cases/advanced-developer-use-cases/persistence/persistence-with-postgresql.adoc
@@ -21,12 +21,13 @@ For more information about Quarkus and JDBC, see link:{quarkus_datasource_guide}
 To see how to configure the PostgreSQL persistence, we recommend that follow the `serverless-workflow-callback-quarkus` example application in the link:{kogito_examples_repository_url}[GitHub repository], or apply the <<#configuration_procedure, configuration procedure>> directly in your project.
 
 .Getting the serverless-workflow-callback-quarkus application
-. In a command terminal, clone the `kogito-examples` repository, navigate to the cloned directory, and follow link:{kogito_sw_examples_url}/serverless-workflow-callback-quarkus/README.md[these steps]:
-[source, bash]
-----
-git clone https://github.com/apache/incubator-kie-kogito-examples.git
+. In a command terminal, clone the `{kie_kogito_examples_repo_name}` repository, navigate to the cloned directory, and follow link:{kogito_sw_examples_url}/serverless-workflow-callback-quarkus/README.md[these steps]:
 
-cd kogito-examples/serverless-workflow-examples/serverless-workflow-callback-quarkus
+[source,bash,subs="attributes+"]
+----
+git clone {kogito_examples_url}
+
+cd {kie_kogito_examples_repo_name}/serverless-workflow-examples/serverless-workflow-callback-quarkus
 ----
 
 .Prerequisites

--- a/serverlessworkflow/modules/ROOT/pages/use-cases/advanced-developer-use-cases/timeouts/timeout-showcase-example.adoc
+++ b/serverlessworkflow/modules/ROOT/pages/use-cases/advanced-developer-use-cases/timeouts/timeout-showcase-example.adoc
@@ -233,13 +233,13 @@ And thus, there is no need for additional configurations when you use timeouts.
 
 To execute the workflows you must:
 
-In a command terminal, clone the `kogito-examples` repository, navigate to the cloned directory, and follow https://github.com/apache/incubator-kie-kogito-examples/tree/main/serverless-workflow-examples/serverless-workflow-timeouts-showcase-operator-devprofile/README.md[these steps]:
+In a command terminal, clone the `{kie_kogito_examples_repo_name}` repository, navigate to the cloned directory, and follow https://github.com/apache/incubator-kie-kogito-examples/tree/main/serverless-workflow-examples/serverless-workflow-timeouts-showcase-operator-devprofile/README.md[these steps]:
 
-[source, bash]
+[source,bash,subs="attributes+"]
 ----
-git clone https://github.com/apache/incubator-kie-kogito-examples.git
+git clone {kogito_examples_url}
 
-cd kogito-examples/serverless-workflow-examples/serverless-workflow-timeouts-showcase-operator-devprofile
+cd {kie_kogito_examples_repo_name}/serverless-workflow-examples/serverless-workflow-timeouts-showcase-operator-devprofile
 ----
 
 [#execute-quarkus-project-embedded-services]
@@ -247,13 +247,13 @@ cd kogito-examples/serverless-workflow-examples/serverless-workflow-timeouts-sho
 
 Similar to the <<#execute-operator-dev-profile, {operator_name} Dev Profile>>, this scenario shows how to configure the embedded {job_service_xref}[job service] and {data_index_xref}[data index service], when you work with a Quarkus Workflow project and it is also intended for development purposes.
 
-In a command terminal, clone the `kogito-examples` repository, navigate to the cloned directory, and follow link:{kogito_sw_examples_url}/serverless-workflow-timeouts-showcase-embedded/README.md[these steps]:
+In a command terminal, clone the `{kie_kogito_examples_repo_name}` repository, navigate to the cloned directory, and follow link:{kogito_sw_examples_url}/serverless-workflow-timeouts-showcase-embedded/README.md[these steps]:
 
-[source, bash]
+[source,bash,subs="attributes+"]
 ----
-git clone https://github.com/apache/incubator-kie-kogito-examples.git
+git clone {kogito_examples_url}
 
-cd kogito-examples/serverless-workflow-examples/serverless-workflow-timeouts-showcase-embedded
+cd {kie_kogito_examples_repo_name}/serverless-workflow-examples/serverless-workflow-timeouts-showcase-embedded
 ----
 
 
@@ -297,13 +297,13 @@ For simplification purposes, a single database instance is used for both service
 
 To execute the workflows you must:
 
-In a command terminal, clone the `kogito-examples` repository, navigate to the cloned directory, and follow link:{kogito_sw_examples_url}/serverless-workflow-timeouts-showcase-extended/README.md[these steps]:
+In a command terminal, clone the `{kie_kogito_examples_repo_name}` repository, navigate to the cloned directory, and follow link:{kogito_sw_examples_url}/serverless-workflow-timeouts-showcase-extended/README.md[these steps]:
 
-[source, bash]
+[source,bash,subs="attributes+"]
 ----
-git clone https://github.com/apache/incubator-kie-kogito-examples.git
+git clone {kogito_examples_url}
 
-cd kogito-examples/serverless-workflow-examples/serverless-workflow-timeouts-showcase-extended
+cd {kie_kogito_examples_repo_name}/serverless-workflow-examples/serverless-workflow-timeouts-showcase-extended
 ----
 
 


### PR DESCRIPTION
<!-- Please don't forget your Issue link -->
Closes #593

<!-- Please provide a short description of what this PR does -->
**Description:**
In the security chapters the old name of the examples repository was used in the commands. This PR fixes also other use cases.
- Creates a new constant `kie_kogito_examples_repo_name` and replaces the occurrences in the docs. 
- Replaces kogito examples git url with `kogito_examples_url`

```yaml
kogito_examples_url: https://github.com/apache/incubator-kie-kogito-examples.git
kie_kogito_examples_repo_name: incubator-kie-kogito-examples
```