### PR TITLE
kie-kogito-docs-672: Create a new SonataFlow guide for Knative Eventing Integration with Jobs Service and Data Index

### DIFF
--- a/serverlessworkflow/antora.yml
+++ b/serverlessworkflow/antora.yml
@@ -138,6 +138,8 @@ asciidoc:
     docker_compose_install_url: https://docs.docker.com/compose/install/
     kn_cli_install_url: https://knative.dev/docs/client/install-kn/
     knative_eventing_url: https://knative.dev/docs/eventing/
+    knative_eventing_broker_url: https://knative.dev/docs/eventing/brokers/
+    knative_eventing_kafka_broker_url: https://knative.dev/docs/eventing/brokers/broker-types/kafka-broker/
     knative_eventing_trigger_url: https://knative.dev/docs/eventing/triggers/
     knative_eventing_sink_binding_url: https://knative.dev/docs/eventing/sinks/#sink-parameter-example
     knative_quickstart_url: https://knative.dev/docs/install/quickstart-install/#install-the-knative-cli/

--- a/serverlessworkflow/modules/ROOT/pages/cloud/operator/configuring-knative-eventing-resources.adoc
+++ b/serverlessworkflow/modules/ROOT/pages/cloud/operator/configuring-knative-eventing-resources.adoc
@@ -319,7 +319,7 @@ spec:
 
 === SonataFlow CR configuration
 
-To configure a workflow you must create a `SonataFlow CR` that fulfil your requirements as usual.
+To configure a workflow you must create a `SonataFlow CR` that fulfills your requirements as usual.
 And finally, prior to deployment into the cluster, add the `env` variables shown below to the field `spec.podTemplate.container`.
 
 .Workflow configuration

--- a/serverlessworkflow/modules/ROOT/pages/cloud/operator/configuring-knative-eventing-resources.adoc
+++ b/serverlessworkflow/modules/ROOT/pages/cloud/operator/configuring-knative-eventing-resources.adoc
@@ -43,7 +43,7 @@ For more information on Knative Brokers link:{knative_eventing_broker_url}[see].
 
 [NOTE]
 ====
-The example creates an in-memory broker for simplicity. In production environments you must use a production ready broker, like the link:{knative_eventing_kafka_broker_url}[Knative Kafka] broker.
+The example creates an in-memory broker for simplicity. In production environments, you must use a production-ready broker, like the link:{knative_eventing_kafka_broker_url}[Knative Kafka] broker.
 ====
 
 [[querying_broker_url]]

--- a/serverlessworkflow/modules/ROOT/pages/cloud/operator/configuring-knative-eventing-resources.adoc
+++ b/serverlessworkflow/modules/ROOT/pages/cloud/operator/configuring-knative-eventing-resources.adoc
@@ -6,7 +6,7 @@
 :description: Configuration of knative eventing deployed by the operator
 :keywords: kogito, sonataflow, workflow, serverless, operator, kubernetes, knative, knative-eventing, events
 
-This document describes how to configure the workflows, and the supporting services, to use link:{knative_eventing_url}[Knative Eventing] as preferred eventing system.
+This document describes how to configure the workflows, and the supporting services, to use link:{knative_eventing_url}[Knative Eventing] as the preferred eventing system.
 
 In general, the following events are produced in a {product_name} installation:
 

--- a/serverlessworkflow/modules/ROOT/pages/cloud/operator/configuring-knative-eventing-resources.adoc
+++ b/serverlessworkflow/modules/ROOT/pages/cloud/operator/configuring-knative-eventing-resources.adoc
@@ -1,60 +1,425 @@
 = Knative Eventing
+:sectnums:
+
 :compat-mode!:
 // Metadata:
-:description: Configuration of knatve eventing deployed by the operator
+:description: Configuration of knative eventing deployed by the operator
 :keywords: kogito, sonataflow, workflow, serverless, operator, kubernetes, knative, knative-eventing, events
 
-This document describes how you can configure the workflows to let operator create the Knative eventing resources on Kubernetes.
+This document describes how to configure the workflows, and the supporting services, to use link:{knative_eventing_url}[Knative Eventing] as preferred eventing system.
 
-{operator_name} can analyze the event definitions from the `spec.flow` and create `SinkBinding`/`Trigger` based on the type of the event. Then the workflow service can utilize them for event communications.
+In general, the following events are produced in a {product_name} installation:
+
+* Workflow outgoing and incoming business events.
+* {product_name} system events sent from the workflow to the Data Index and Job Service respectively.
+* {product_name} system events sent from the Jobs Service to the Data Index Service.
+
+[IMPORTANT]
+====
+These content of this guide must be used only when you work with workflows using the `preview` and `gitops` profiles.
+====
+
+To produce a successful configuration you must follow this procedure:
+
+== Prerequisite
+
+1. The {operator_name} installed. See xref:cloud/operator/install-serverless-operator.adoc[] guide.
+2. The link:{knative_eventing_url}[Knative Eventing] system is installed and property initiated in the cluster.
+
+== Configuring the Knative Broker
+
+Create a Knative Broker to define the event mesh to collect the events with a resource like this:
+
+[source,yaml]
+----
+apiVersion: eventing.knative.dev/v1
+kind: Broker
+metadata:
+  name: default
+  namespace: example-namespace
+----
+
+For more information on Knative Brokers link:{knative_eventing_broker_url}[see].
 
 [NOTE]
 ====
- Alternativelly, you can follow our xref:use-cases/advanced-developer-use-cases/event-orchestration/consume-produce-events-with-knative-eventing.adoc#ref-example-sw-event-definition-knative[advanced guide] that uses Java and Quarkus to introduce this feature.
+The example creates an in-memory broker for simplicity. In production environments you must use a production ready broker, like the link:{knative_eventing_kafka_broker_url}[Knative Kafka] broker.
 ====
 
-== Prerequisite
-1. The {operator_name} installed. See xref:cloud/operator/install-serverless-operator.adoc[] guide.
-2. Knative is installed on the cluster and Knative Eventing is initiated with a `KnativeEventing` CR.
-3. A broker named `default` is created. Currently, all Triggers created by the {operator_name} will read events from `default`
+[[querying_broker_url]]
+Finally, to get the Broker URL that is needed in the next steps of the configuration, you can execute the following command:
 
-== Configuring the workflow
+[source,bash]
+----
+kubectl get broker -n example-namespace
 
-For the operator to create the `SinkBinding` resources, the workflow must provide the sink information in `spec.sink`.
+NAME      URL                                                                     AGE     READY   REASON
+default   http://broker-ingress.knative-eventing.svc.cluster.local/example-namespace/default   4m50s   True
+----
 
-.Example of a workflow with events
-[source,yaml,subs="attributes+"]
---
+For a link:{knative_eventing_kafka_broker_url}[Knative Kafka] broker that the URL will look like this instead.
+
+[source,bash]
+----
+http://kafka-broker-ingress.knative-eventing.svc.cluster.local/example-namespace/default
+----
+
+== Configuring the Data Index Knative Eventing Resources
+
+=== Workflows to DataIndex system events
+
+Create the following Knative Triggers to deliver all the {product_name} system events sent from the workflows to the Data Index Service:
+
+[NOTE]
+====
+In your installation you might have to adjust the `spec.broker`, the `spec.subscriber.ref.name`, and `spec.subscriber.ref.namespace` fields to use the correct names for every trigger.
+====
+
+For more information on Knative Triggers link:{knative_eventing_trigger_url}[see].
+
+.Process definition events trigger
+[source,yaml]
+----
+apiVersion: eventing.knative.dev/v1
+kind: Trigger
+metadata:
+  name: sonataflow-platform-data-index-service-process-def-trigger
+spec:
+  broker: default
+  filter:
+    attributes:
+      type: ProcessDefinitionEvent
+  subscriber:
+    ref:
+      apiVersion: v1
+      kind: Service
+      name: sonataflow-platform-data-index-service
+      namespace: example-namespace
+    uri: /definitions
+----
+
+.Process instance state events trigger
+[source,yaml]
+----
+apiVersion: eventing.knative.dev/v1
+kind: Trigger
+metadata:
+  name: sonataflow-platform-data-index-service-process-state-trigger
+spec:
+  broker: default
+  filter:
+    attributes:
+      type: ProcessInstanceStateDataEvent
+  subscriber:
+    ref:
+      apiVersion: v1
+      kind: Service
+      name: sonataflow-platform-data-index-service
+      namespace: example-namespace
+    uri: /processes
+----
+
+.Process instance node events trigger
+[source,yaml]
+----
+apiVersion: eventing.knative.dev/v1
+kind: Trigger
+metadata:
+  name: sonataflow-platform-data-index-service-process-node-trigger
+spec:
+  broker: default
+  filter:
+    attributes:
+      type: ProcessInstanceNodeDataEvent
+  subscriber:
+    ref:
+      apiVersion: v1
+      kind: Service
+      name: sonataflow-platform-data-index-service
+      namespace: example-namespace
+    uri: /processes
+----
+
+.Process instance error events trigger
+[source,yaml]
+----
+apiVersion: eventing.knative.dev/v1
+kind: Trigger
+metadata:
+  name: sonataflow-platform-data-index-service-process-error-trigger
+spec:
+  broker: default
+  filter:
+    attributes:
+      type: ProcessInstanceErrorDataEvent
+  subscriber:
+    ref:
+      apiVersion: v1
+      kind: Service
+      name: sonataflow-platform-data-index-service
+      namespace: example-namespace
+    uri: /processes
+----
+
+.Process instance SLA events trigger
+[source,yaml]
+----
+apiVersion: eventing.knative.dev/v1
+kind: Trigger
+metadata:
+  name: sonataflow-platform-data-index-service-process-sla-trigger
+spec:
+  broker: default
+  filter:
+    attributes:
+      type: ProcessInstanceSLADataEvent
+  subscriber:
+    ref:
+      apiVersion: v1
+      kind: Service
+      name: sonataflow-platform-data-index-service
+      namespace: example-namespace
+    uri: /processes
+----
+
+.Process instance variable events trigger
+[source,yaml]
+----
+apiVersion: eventing.knative.dev/v1
+kind: Trigger
+metadata:
+  name: sonataflow-platform-data-index-service-process-variable-trigger
+spec:
+  broker: default
+  filter:
+    attributes:
+      type: ProcessInstanceVariableDataEvent
+  subscriber:
+    ref:
+      apiVersion: v1
+      kind: Service
+      name: sonataflow-platform-data-index-service
+      namespace: example-namespace
+    uri: /processes
+----
+
+=== Job Service to Data Index system events
+
+Create the following Knative Trigger to deliver all the {product_name} system events sent from the Job Service to the Data Index Service:
+
+[NOTE]
+====
+In your installation you might have to adjust the `spec.broker`, the `spec.subscriber.ref.name`, and `spec.subscriber.ref.namespace` fields to use the correct names for every trigger.
+====
+
+For more information on Knative Triggers link:{knative_eventing_trigger_url}[see].
+
+.Job events trigger
+[source,yaml]
+----
+apiVersion: eventing.knative.dev/v1
+kind: Trigger
+metadata:
+  name: sonataflow-platform-data-index-service-jobs-trigger
+spec:
+  broker: default
+  filter:
+    attributes:
+      type: JobEvent
+  subscriber:
+    ref:
+      apiVersion: v1
+      kind: Service
+      name: sonataflow-platform-data-index-service
+      namespace: example-namespace
+    uri: /jobs
+----
+
+== Configuring the Job Service Knative Eventing Resources
+
+Create the following Knative Triggers to deliver all the {product_name} system events produced by the workflows to the Job Service:
+
+[NOTE]
+====
+In your installation you might have to adjust the `spec.broker`, the `spec.subscriber.ref.name`, and `spec.subscriber.ref.namespace` fields to use the correct names for every trigger.
+====
+
+.Create Job events trigger
+[source,yaml]
+----
+apiVersion: eventing.knative.dev/v1
+kind: Trigger
+metadata:
+  name: sonataflow-platform-jobs-service-create-job-trigger
+spec:
+  broker: default
+  filter:
+    attributes:
+      type: job.create
+  subscriber:
+    ref:
+      apiVersion: v1
+      kind: Service
+      name: sonataflow-platform-jobs-service
+      namespace: example-namespace
+    uri: /v2/jobs/events
+----
+
+.Delete Job events trigger
+[source,yaml]
+----
+apiVersion: eventing.knative.dev/v1
+kind: Trigger
+metadata:
+  name: jobs-service-postgresql-delete-job-trigger
+  namespace: example-namespace
+spec:
+  broker: default
+  filter:
+    attributes:
+      type: job.delete
+  subscriber:
+    ref:
+      apiVersion: v1
+      kind: Service
+      name: sonataflow-platform-jobs-service
+      namespace: example-namespace
+    uri: /v2/jobs/events
+----
+
+== Data Index and Job Service installation
+
+To deploy these services you must use a `SonataFlowPlatform CR` and configure it according to the xref:cloud/operator/supporting-services.adoc[Supporting Services guide].
+Finally, prior to deployment into the cluster, you must add the `env` variable shown below to the field `spec.jobService.podTemplate.container`.
+
+[source,yaml]
+----
+apiVersion: sonataflow.org/v1alpha08
+kind: SonataFlowPlatform
+metadata:
+  name: sonataflow-platform
+  namespace: example-namespace
+spec:
+  services:
+    dataIndex:
+      # Data Index requires no additional configurations to use knative eventing.
+      # Use the configuration of your choice according to the Supporting Services guide.
+    jobService:
+      podTemplate:
+        container:
+          env:
+            - name: MP_MESSAGING_OUTGOING_KOGITO_JOB_SERVICE_JOB_STATUS_EVENTS_HTTP_URL <1>
+              value: http://broker-ingress.knative-eventing.svc.cluster.local/example-namespace/default <2>
+----
+
+<1> Fixed env variable name that contains the URL of the Broker created in <<_configuring_the_knative_broker>>.
+<2> To query the Broker URL <<querying_broker_url, see>>.
+
+== Workflow configuration
+
+=== SonataFlow CR configuration
+
+To configure a workflow you must create a `SonataFlow CR` that fulfil your requirements as usual.
+And finally, prior to deployment into the cluster, add the `env` variables shown below to the field `spec.podTemplate.container`.
+
+.Workflow configuration
+[source,yaml]
+----
 apiVersion: sonataflow.org/v1alpha08
 kind: SonataFlow
 metadata:
-...
+  name: example-workflow
+  namespace: example-namespace
+  annotations:
+    sonataflow.org/description: Example Workflow that show Knative Eventing configuration.
+    sonataflow.org/version: 0.0.1
+    sonataflow.org/profile: preview
 spec:
-  sink:
-    ref: <1>
-      name: default
-      namespace: greeting
-      apiVersion: eventing.knative.dev/v1
-      kind: Broker
+  podTemplate:
+    container:
+      env:
+        - name: K_SINK <1>
+          value: http://broker-ingress.knative-eventing.svc.cluster.local/example-namespace/default <2>
+        - name: MP_MESSAGING_OUTGOING_KOGITO_JOB_SERVICE_JOB_REQUEST_EVENTS_URL
+          value: ${K_SINK}
+        - name: MP_MESSAGING_OUTGOING_KOGITO_PROCESSINSTANCES_EVENTS_URL
+          value: ${K_SINK}
+        - name: MP_MESSAGING_OUTGOING_KOGITO_PROCESSDEFINITIONS_EVENTS_URL
+          value: ${K_SINK}
   flow:
-    events: <2>
-      - name: requestQuote
-        type: kogito.sw.request.quote
-        kind: produced
-      - name: aggregatedQuotesResponse,
-        type: kogito.loanbroker.aggregated.quotes.response,
-        kind: consumed,
-        source: /kogito/serverless/loanbroker/aggregator
-...
---
-<1> `spec.sink.ref` defines the sink that all created sinkBinding will use as the destination sink for producing events
-<2> `spec.flow.events` lists all the events referenced in the workflow. Events with `produced` kind will trigger the creation of `SinkBindings` by the {operator_name}, while those labeled as `consumed` will lead to the generation of `Triggers`.
+    start: ExampleState
+    events:
+      - name: exampleConsumedEvent1
+        source: ''
+        type: example_event_1 <3>
+        kind: consumed
+      - name: exampleConsumedEvent2
+        source: ''
+        type: example_event_2 <4>
+        kind: consumed
+----
+
+<1> Fixed env variable name that contains the URL of the broker created in <<_configuring_the_knative_broker>>.
+<2> Must contain the broker URL. To get this value <<querying_broker_url, see>>. The remaining env variables are fixed configurations, and you must add them as is.
+<3> Every consumed event requires a trigger, <<trigger-event-type1, see>>.
+<4> Every consumed event requires a trigger, <<trigger-event-type2, see>>.
+
+=== Configuring the Workflow Knative Eventing Resources
+
+For every event type consumed by the workflow you must create a corresponding trigger to deliver it from the broker.
 
 [NOTE]
 ====
-Knative resources are not watched by the operator, indicating they will not undergo automatic reconciliation. This grants users the freedom to make updates at their preference.
+Unlike the triggers related to the Data Index Service and the Jobs Service, these triggers must be created for every workflow that consume events.
+So it's recommended that you use trigger names that are linked to the workflow name.
 ====
 
+[[trigger-event-type1]]
+.Trigger to consume events of type example_event_1
+[source,yaml]
+----
+apiVersion: eventing.knative.dev/v1
+kind: Trigger
+metadata:
+  name: example-workflow-example-event-1-trigger <1>
+spec:
+  broker: default
+  filter:
+    attributes:
+      type: example_event_1 <2>
+  subscriber:
+    ref:
+      apiVersion: v1
+      kind: Service
+      name: example-workflow
+      namespace: example-namespace
+----
+
+<1> Name for the trigger.
+<2> Event type consumed by the workflow `example-workflow`.
+
+[[trigger-event-type2]]
+.Trigger to consume events of type example_event_2
+[source,yaml]
+----
+apiVersion: eventing.knative.dev/v1
+kind: Trigger
+metadata:
+  name: example-workflow-example-event-2-trigger <1>
+spec:
+  broker: default
+  filter:
+    attributes:
+      type: example_event_2
+  subscriber:
+    ref:
+      apiVersion: v1
+      kind: Service
+      name: example-workflow
+      namespace: example-namespace
+----
+
+:sectnums!:
 == Additional resources
 
 * https://knative.dev/docs/eventing/[Knative Eventing official site]

--- a/serverlessworkflow/modules/ROOT/pages/cloud/operator/configuring-knative-eventing-resources.adoc
+++ b/serverlessworkflow/modules/ROOT/pages/cloud/operator/configuring-knative-eventing-resources.adoc
@@ -6,7 +6,7 @@
 :description: Configuration of knative eventing deployed by the operator
 :keywords: kogito, sonataflow, workflow, serverless, operator, kubernetes, knative, knative-eventing, events
 
-This document describes how to configure the workflows, and the supporting services, to use link:{knative_eventing_url}[Knative Eventing] as the preferred eventing system.
+This document describes how to configure workflows, and the supporting services, to use link:{knative_eventing_url}[Knative Eventing] as the preferred eventing system.
 
 In general, the following events are produced in a {product_name} installation:
 

--- a/serverlessworkflow/modules/ROOT/pages/cloud/operator/configuring-knative-eventing-resources.adoc
+++ b/serverlessworkflow/modules/ROOT/pages/cloud/operator/configuring-knative-eventing-resources.adoc
@@ -23,7 +23,7 @@ To produce a successful configuration you must follow this procedure:
 
 == Prerequisite
 
-1. The {operator_name} installed. See xref:cloud/operator/install-serverless-operator.adoc[] guide.
+1. The {operator_name} is installed. See xref:cloud/operator/install-serverless-operator.adoc[] guide.
 2. The link:{knative_eventing_url}[Knative Eventing] system is installed and property initiated in the cluster.
 
 == Configuring the Knative Broker

--- a/serverlessworkflow/modules/ROOT/pages/cloud/operator/configuring-knative-eventing-resources.adoc
+++ b/serverlessworkflow/modules/ROOT/pages/cloud/operator/configuring-knative-eventing-resources.adoc
@@ -16,7 +16,7 @@ In general, the following events are produced in a {product_name} installation:
 
 [IMPORTANT]
 ====
-These content of this guide must be used only when you work with workflows using the `preview` and `gitops` profiles.
+The content of this guide must be used only when you work with workflows using the `preview` and `gitops` profiles.
 ====
 
 To produce a successful configuration you must follow this procedure:

--- a/serverlessworkflow/modules/ROOT/pages/cloud/operator/configuring-knative-eventing-resources.adoc
+++ b/serverlessworkflow/modules/ROOT/pages/cloud/operator/configuring-knative-eventing-resources.adoc
@@ -319,7 +319,7 @@ spec:
 
 === SonataFlow CR configuration
 
-To configure a workflow you must create a `SonataFlow CR` that fulfills your requirements as usual.
+To configure a workflow you must create a `SonataFlow` CR that fulfills your requirements.
 And finally, prior to deployment into the cluster, add the `env` variables shown below to the field `spec.podTemplate.container`.
 
 .Workflow configuration

--- a/serverlessworkflow/modules/ROOT/pages/cloud/operator/configuring-knative-eventing-resources.adoc
+++ b/serverlessworkflow/modules/ROOT/pages/cloud/operator/configuring-knative-eventing-resources.adoc
@@ -289,7 +289,7 @@ spec:
 
 == Data Index and Job Service installation
 
-To deploy these services you must use a `SonataFlowPlatform CR` and configure it according to the xref:cloud/operator/supporting-services.adoc[Supporting Services guide].
+To deploy these services you must use a `SonataFlowPlatform` CR and configure it according to the xref:cloud/operator/supporting-services.adoc[Supporting Services guide].
 Finally, prior to deployment into the cluster, you must add the `env` variable shown below to the field `spec.jobService.podTemplate.container`.
 
 [source,yaml]


### PR DESCRIPTION
<!-- Please don't forget your Issue link -->
Closes #627 

<!-- Please provide a short description of what this PR does -->
**Description:**

<!-- Link to related PRs: -->

Please make sure that your PR meets the following requirements:

- [X] You have read the [contributions doc](https://github.com/apache/incubator-kie-kogito-docs/blob/main/CONTRIBUTING.md)
- [X] Pull Request title is properly formatted: `Issue-XYZ Subject`
- [X] Pull Request title contains the target branch if not targeting main: `[0.9.x] Issue-XYZ Subject`
- [X] The nav.adoc file has a link to this guide in the proper category
- [X] The index.adoc file has a card to this guide in the proper category, with a meaningful description

<details>
<summary>
How to backport a pull request to a different branch?
</summary>

In order to automatically create a **backporting pull request** please add one or more labels having the following format `backport-<branch-name>`, where `<branch-name>` is the name of the branch where the pull request must be backported to (e.g., `backport-7.67.x` to backport the original PR to the `7.67.x` branch).

> **NOTE**: **backporting** is an action aiming to move a change (usually a commit) from a branch (usually the main one) to another one, which is generally referring to a still maintained release branch. Keeping it simple: it is about to move a specific change or a set of them from one branch to another.

Once the original pull request is successfully merged, the automated action will create one backporting pull request per each label (with the previous format) that has been added.

If something goes wrong, the author will be notified and at this point a manual backporting is needed.

> **NOTE**: this automated backporting is triggered whenever a pull request on `main` branch is labeled or closed, but both conditions must be satisfied to get the new PR created.
</details>