### PR TITLE
NO ISSUE - Fix a wrong attribute under platform spec.properties

### DIFF
--- a/serverlessworkflow/modules/ROOT/pages/cloud/operator/using-persistence.adoc
+++ b/serverlessworkflow/modules/ROOT/pages/cloud/operator/using-persistence.adoc
@@ -256,7 +256,7 @@ spec:
 
 === Flyway configuration by using SonataFlowPlatForm properties
 
-To apply a common Flyway configuration to all the workflows in a given namespace, you can use the `spec.properties` of the `SonataFlowPlatform` in that namespace.
+To apply a common Flyway configuration to all the workflows in a given namespace, you can use the `spec.properties.flow` of the `SonataFlowPlatform` in that namespace.
 
 .Example of enabling Flyway by using the SonataFlowPlatform properties.
 [source,yaml]
@@ -267,13 +267,14 @@ metadata:
   name: sonataflow-platform
 spec:
   properties:
-    - name: quarkus.flyway.migrate-at-start
-      value: true
+       flow:
+          - name: quarkus.flyway.migrate-at-start
+            value: true
 ----
 
 [NOTE]
 ====
-The configuration above takes effect at workflow deployment time, so you must be sure that property is configured before you deploy your workflows.
+The configuration above takes effect at workflow deployment time, so you must be sure that the property is configured before you deploy your workflows.
 ====
 
 === Manual database initialization by using DDL


### PR DESCRIPTION
We are missing the `flow` attribute under `spec.properties`:

```shell
The SonataFlowPlatform "sonataflow-platform" is invalid: spec.properties: Invalid value: "array": spec.properties in body must be of type object: "array"
```

<!-- Link to related PRs: -->

Please make sure that your PR meets the following requirements:

- [ ] You have read the [contributions doc](https://github.com/apache/incubator-kie-kogito-docs/blob/main/CONTRIBUTING.md)
- [ ] Pull Request title is properly formatted: `Issue-XYZ Subject`
- [ ] Pull Request title contains the target branch if not targeting main: `[0.9.x] Issue-XYZ Subject`
- [ ] The nav.adoc file has a link to this guide in the proper category
- [ ] The index.adoc file has a card to this guide in the proper category, with a meaningful description

<details>
<summary>
How to backport a pull request to a different branch?
</summary>

In order to automatically create a **backporting pull request** please add one or more labels having the following format `backport-<branch-name>`, where `<branch-name>` is the name of the branch where the pull request must be backported to (e.g., `backport-7.67.x` to backport the original PR to the `7.67.x` branch).

> **NOTE**: **backporting** is an action aiming to move a change (usually a commit) from a branch (usually the main one) to another one, which is generally referring to a still maintained release branch. Keeping it simple: it is about to move a specific change or a set of them from one branch to another.

Once the original pull request is successfully merged, the automated action will create one backporting pull request per each label (with the previous format) that has been added.

If something goes wrong, the author will be notified and at this point a manual backporting is needed.

> **NOTE**: this automated backporting is triggered whenever a pull request on `main` branch is labeled or closed, but both conditions must be satisfied to get the new PR created.
</details>