### PR TITLE
Issue-678 Improve `between` operator description

### DIFF
--- a/serverlessworkflow/modules/ROOT/pages/data-index/data-index-core-concepts.adoc
+++ b/serverlessworkflow/modules/ROOT/pages/data-index/data-index-core-concepts.adoc
@@ -256,9 +256,7 @@ Depending on the attribute type, the following operators are also available:
 ** `greaterThanEqual`: Integer
 ** `lessThan`: Integer
 ** `lessThanEqual`: Integer
-** `between`: Numeric range
-** `from`: Integer
-** `to`: Integer
+** `between`: Numeric range (with `from` and `to` Integer values required)
 
 * Date argument:
 ** `isNull`: Boolean (`true` or `false`)
@@ -267,9 +265,7 @@ Depending on the attribute type, the following operators are also available:
 ** `greaterThanEqual`: Date time
 ** `lessThan`: Date time
 ** `lessThanEqual`: Date time
-** `between`: Date range
-** `from`: Date time
-** `to`: Date time
+** `between`: Date range (with `from` and `to` Date time values required)
 --
 
 Sort query results using the `orderBy` parameter::


### PR DESCRIPTION
<!-- Please don't forget your Issue link -->
Resolves Issue #678 

<!-- Please provide a short description of what this PR does -->
**Description:**
`from` and `to` are not standalone operators.
They can only be used as part of the `between` operator.

Please make sure that your PR meets the following requirements:

- [x] You have read the [contributions doc](https://github.com/apache/incubator-kie-kogito-docs/blob/main/CONTRIBUTING.md)
- [x] Pull Request title is properly formatted: `Issue-XYZ Subject`
- [x] Pull Request title contains the target branch if not targeting main: `[0.9.x] Issue-XYZ Subject`
- [x] The nav.adoc file has a link to this guide in the proper category
- [x] The index.adoc file has a card to this guide in the proper category, with a meaningful description

<details>
<summary>
How to backport a pull request to a different branch?
</summary>

In order to automatically create a **backporting pull request** please add one or more labels having the following format `backport-<branch-name>`, where `<branch-name>` is the name of the branch where the pull request must be backported to (e.g., `backport-7.67.x` to backport the original PR to the `7.67.x` branch).

> **NOTE**: **backporting** is an action aiming to move a change (usually a commit) from a branch (usually the main one) to another one, which is generally referring to a still maintained release branch. Keeping it simple: it is about to move a specific change or a set of them from one branch to another.

Once the original pull request is successfully merged, the automated action will create one backporting pull request per each label (with the previous format) that has been added.

If something goes wrong, the author will be notified and at this point a manual backporting is needed.

> **NOTE**: this automated backporting is triggered whenever a pull request on `main` branch is labeled or closed, but both conditions must be satisfied to get the new PR created.
</details>