### PR TITLE
kie-kogito-docs-664: Create a guide for the SonataFlow Operator driven Supporting Services Knative Eventing system configuration

### DIFF
--- a/serverlessworkflow/modules/ROOT/pages/cloud/operator/supporting-services.adoc
+++ b/serverlessworkflow/modules/ROOT/pages/cloud/operator/supporting-services.adoc
@@ -327,7 +327,7 @@ When you use a <<cluster-scoped-deployment>> deployment, the supporting services
 
 To configure the eventing system for a supporting service, the {operator_name} use the following precedence rules:
 
-* If the supporting service has a configured eventing system, by using any of the <<data-index-eventing-system-configuration>> or <<jos-service-eventing-system-configuration>> respectively, that configuration apply.
+* If the supporting service has a configured eventing system, by using any of the <<data-index-eventing-system-configuration>> or <<jos-service-eventing-system-configuration>> respectively, that configuration applies.
 
 * If the `SonataFlowPlatform` CR enclosing the supporting service, is configured with a <<platform-scoped-eventing-system-configuration>>, that configuration apply.
 

--- a/serverlessworkflow/modules/ROOT/pages/cloud/operator/supporting-services.adoc
+++ b/serverlessworkflow/modules/ROOT/pages/cloud/operator/supporting-services.adoc
@@ -323,7 +323,7 @@ In production environments, you must use production-ready brokers, like the link
 
 When you use a <<cluster-scoped-deployment>> deployment, the supporting services are automatically linked to the `Broker` configured in the `SonataFlowPlatform` CR referred to by the `SonataFlowClusterPlatform` CR.
 
-=== Eventing System configuration precedence rules
+=== Eventing system configuration precedence rules
 
 To configure the eventing system for a supporting service, the {operator_name} use the following precedence rules:
 

--- a/serverlessworkflow/modules/ROOT/pages/cloud/operator/supporting-services.adoc
+++ b/serverlessworkflow/modules/ROOT/pages/cloud/operator/supporting-services.adoc
@@ -329,7 +329,7 @@ To configure the eventing system for a supporting service, the {operator_name} u
 
 * If the supporting service has a configured eventing system, by using any of the <<data-index-eventing-system-configuration>> or <<jos-service-eventing-system-configuration>> respectively, that configuration applies.
 
-* If the `SonataFlowPlatform` CR enclosing the supporting service, is configured with a <<platform-scoped-eventing-system-configuration>>, that configuration apply.
+* If the `SonataFlowPlatform` CR enclosing the supporting service, is configured with a <<platform-scoped-eventing-system-configuration>>, that configuration applies.
 
 * If the current cluster, is configured with a <<cluster-scoped-eventing-system-configuration>>, that configuration apply.
 

--- a/serverlessworkflow/modules/ROOT/pages/cloud/operator/supporting-services.adoc
+++ b/serverlessworkflow/modules/ROOT/pages/cloud/operator/supporting-services.adoc
@@ -333,7 +333,7 @@ To configure the eventing system for a supporting service, the {operator_name} u
 
 * If the current cluster, is configured with a <<cluster-scoped-eventing-system-configuration>>, that configuration apply.
 
-* If none of the previous configurations exists, the supporting service is configured to produce direct Http calls to deliver events.
+* If none of the previous configurations exists, the supporting service is configured to produce direct HTTP calls to deliver events.
 
 === Eventing System linking objects
 

--- a/serverlessworkflow/modules/ROOT/pages/cloud/operator/supporting-services.adoc
+++ b/serverlessworkflow/modules/ROOT/pages/cloud/operator/supporting-services.adoc
@@ -227,7 +227,7 @@ spec:
 ----
 
 <1> Name of the Knative Eventing Broker.
-<2> Optional: Defines the namespace of the Knative Eventing Broker. Defaults to the SonataFlowPlatform namespace. In general, we recommend to create the Knative Eventing Broker in the same namespace as the SonataFlowPlatform.
+<2> Optional: Defines the namespace of the Knative Eventing Broker. Defaults to the SonataFlowPlatform namespace. In general, we recommend creating the Knative Eventing Broker in the same namespace as the SonataFlowPlatform.
 
 [NOTE]
 ====

--- a/serverlessworkflow/modules/ROOT/pages/cloud/operator/supporting-services.adoc
+++ b/serverlessworkflow/modules/ROOT/pages/cloud/operator/supporting-services.adoc
@@ -270,7 +270,7 @@ spec:
 ----
 
 <1> Name of the Knative Eventing Broker to `consume` events from.
-<2> Optional: Defines the namespace of the Knative Eventing Broker. Defaults to the SonataFlowPlatform namespace. In general, we recommend to create the Knative Eventing Broker in the same namespace as the SonataFlowPlatform.
+<2> Optional: Defines the namespace of the Knative Eventing Broker. Defaults to the SonataFlowPlatform namespace. In general, we recommend creating the Knative Eventing Broker in the same namespace as the SonataFlowPlatform.
 
 [NOTE]
 ====

--- a/serverlessworkflow/modules/ROOT/pages/cloud/operator/supporting-services.adoc
+++ b/serverlessworkflow/modules/ROOT/pages/cloud/operator/supporting-services.adoc
@@ -196,7 +196,7 @@ In a regular {product_name} installation, the preferred method is to use the <<p
 ====
 
 [#platform-scoped-eventing-system-configuration]
-=== Platform scoped Eventing System Configuration
+=== Platform-scoped Eventing system configuration
 
 To configure a platform scoped eventing system, you must use the field `spec.eventing.broker.ref` in the `SonataFlowPlatform` CR to refer a Knative Eventing Broker.
 

--- a/serverlessworkflow/modules/ROOT/pages/cloud/operator/supporting-services.adoc
+++ b/serverlessworkflow/modules/ROOT/pages/cloud/operator/supporting-services.adoc
@@ -235,7 +235,7 @@ In production environments, you must use a production-ready broker, like the lin
 ====
 
 [#service-scoped-eventing-system-configuration]
-=== Service scoped Eventing System configuration
+=== Service-scoped Eventing system configuration
 
 A service scoped eventing system configuration provides the ability to do a fine-grained configuration of the eventing system for the <<data-index-eventing-system-configuration, Data Index>> or the <<jos-service-eventing-system-configuration, Jobs Service>>.
 

--- a/serverlessworkflow/modules/ROOT/pages/cloud/operator/supporting-services.adoc
+++ b/serverlessworkflow/modules/ROOT/pages/cloud/operator/supporting-services.adoc
@@ -245,7 +245,7 @@ In a regular {product_name} installation, the preferred method is to use a <<pla
 ====
 
 [#data-index-eventing-system-configuration]
-=== Data Index Eventing System configuration
+=== Data Index Eventing system configuration
 
 To configure a service scoped eventing system for the Data Index, you must use the field `spec.services.dataIndex.source.ref` in the `SonataFlowPlatform` CR to refer a specific Knative Eventing Broker.
 

--- a/serverlessworkflow/modules/ROOT/pages/cloud/operator/supporting-services.adoc
+++ b/serverlessworkflow/modules/ROOT/pages/cloud/operator/supporting-services.adoc
@@ -247,7 +247,7 @@ In a regular {product_name} installation, the preferred method is to use a <<pla
 [#data-index-eventing-system-configuration]
 === Data Index Eventing system configuration
 
-To configure a service scoped eventing system for the Data Index, you must use the field `spec.services.dataIndex.source.ref` in the `SonataFlowPlatform` CR to refer a specific Knative Eventing Broker.
+To configure a service-scoped eventing system for the Data Index, you must use the field `spec.services.dataIndex.source.ref` in the `SonataFlowPlatform` CR to refer to a specific Knative Eventing Broker.
 
 This information signals the {operator_name} to automatically link the Data Index to `consume` the {product_name} system events from that Broker.
 

--- a/serverlessworkflow/modules/ROOT/pages/cloud/operator/supporting-services.adoc
+++ b/serverlessworkflow/modules/ROOT/pages/cloud/operator/supporting-services.adoc
@@ -237,7 +237,7 @@ In production environments, you must use a production-ready broker, like the lin
 [#service-scoped-eventing-system-configuration]
 === Service-scoped Eventing system configuration
 
-A service scoped eventing system configuration provides the ability to do a fine-grained configuration of the eventing system for the <<data-index-eventing-system-configuration, Data Index>> or the <<jos-service-eventing-system-configuration, Jobs Service>>.
+A service scoped eventing system configuration provides the ability to do a fine-grained configuration of the Eventing system for the <<data-index-eventing-system-configuration, Data Index>> or the <<jos-service-eventing-system-configuration, Jobs Service>>.
 
 [NOTE]
 ====

--- a/serverlessworkflow/modules/ROOT/pages/cloud/operator/supporting-services.adoc
+++ b/serverlessworkflow/modules/ROOT/pages/cloud/operator/supporting-services.adoc
@@ -241,7 +241,7 @@ A service scoped eventing system configuration provides the ability to do a fine
 
 [NOTE]
 ====
-In a regular {product_name} installation, the preferred method is to use a <<platform-scoped-eventing-system-configuration, Platform scoped Eventing System Configuration>>, while the service scoped configuration is reserved only for advanced use cases.
+In a regular {product_name} installation, the preferred method is to use a <<platform-scoped-eventing-system-configuration, Platform-scoped Eventing System Configuration>>, while the service-scoped configuration is reserved only for advanced use cases.
 ====
 
 [#data-index-eventing-system-configuration]

--- a/serverlessworkflow/modules/ROOT/pages/cloud/operator/supporting-services.adoc
+++ b/serverlessworkflow/modules/ROOT/pages/cloud/operator/supporting-services.adoc
@@ -311,7 +311,7 @@ spec:
 <1> Name of the Knative Eventing Broker to `consume` events from.
 <2> Optional: Defines the namespace of the Knative Eventing Broker. Defaults to the SonataFlowPlatform namespace. In general, we recommend creating the Knative Eventing Broker in the same namespace as the SonataFlowPlatform.
 <3> Name of the Knative Eventing Broker to `produce` events on.
-<4> Optional: Defines the namespace of the Knative Eventing Broker. Defaults to the SonataFlowPlatform namespace. In general, we recommend to create the Knative Eventing Broker in the same namespace as the SonataFlowPlatform.
+<4> Optional: Defines the namespace of the Knative Eventing Broker. Defaults to the SonataFlowPlatform namespace. In general, we recommend creating the Knative Eventing Broker in the same namespace as the SonataFlowPlatform.
 
 [NOTE]
 ====

--- a/serverlessworkflow/modules/ROOT/pages/cloud/operator/supporting-services.adoc
+++ b/serverlessworkflow/modules/ROOT/pages/cloud/operator/supporting-services.adoc
@@ -180,6 +180,241 @@ When you use the common PostgreSQL configuration, the database schema for each s
 For example, `sonataflow-platform-example-data-index-service`.
 ====
 
+== Configuring the Supporting Services Eventing System
+
+In general, the following events are produced in a {product_name} installation:
+
+* Workflow outgoing and incoming business events.
+* {product_name} system events sent from the workflow to the Data Index and Job Service respectively.
+* {product_name} system events sent from the Jobs Service to the Data Index Service.
+
+The {operator_name} is designed to use the link:{knative_eventing_url}[Knative Eventing] system to resolve all the event communication between these services.
+
+[NOTE]
+====
+In a regular {product_name} installation, the preferred method is to use the <<platform-scoped-eventing-system-configuration, Platform scoped Eventing System Configuration>>, while the <<service-scoped-eventing-system-configuration, Service scoped Eventing System configuration>> is reserved only for advanced use cases.
+====
+
+[#platform-scoped-eventing-system-configuration]
+=== Platform scoped Eventing System Configuration
+
+To configure a platform scoped eventing system, you must use the field `spec.eventing.broker.ref` in the `SonataFlowPlatform` CR to refer a Knative Eventing Broker.
+
+This information signals the {operator_name} to automatically link the supporting services to `produce` and `consume` the events by using that Broker.
+
+Additionally, workflows deployed in that namespace, that don't provide a custom eventing system configuration, will be linked to that Broker.
+// TODO, uncomment when the workflows section is in.
+// For more information about configuring the workflow eventing system, xref:cloud/operator/configuring-workflow-eventing-system.adoc[see].
+
+The following `SonataFlowPlatform` CR fragment shows an example of such configuration:
+
+.Platform scoped eventing system configuration example
+[source,yam]
+----
+apiVersion: sonataflow.org/v1alpha08
+kind: SonataFlowPlatform
+metadata:
+  name: sonataflow-platform-example
+  namespace: example-namespace
+spec:
+  eventing:
+    broker:
+      ref:
+        name: example-broker <1>
+        namespace: example-broker-namespace <2>
+        apiVersion: eventing.knative.dev/v1
+        kind: Broker
+----
+
+<1> Name of the Knative Eventing Broker.
+<2> Optional: Defines the namespace of the Knative Eventing Broker. Defaults to the SonataFlowPlatform namespace. In general, we recommend to create the Knative Eventing Broker in the same namespace as the SonataFlowPlatform.
+
+[NOTE]
+====
+In production environments, you must use a production-ready broker, like the link:{knative_eventing_kafka_broker_url}[Knative Kafka Broker].
+====
+
+[#service-scoped-eventing-system-configuration]
+=== Service scoped Eventing System configuration
+
+A service scoped eventing system configuration provides the ability to do a fine-grained configuration of the eventing system for the <<data-index-eventing-system-configuration, Data Index>> or the <<jos-service-eventing-system-configuration, Jobs Service>>.
+
+[NOTE]
+====
+In a regular {product_name} installation, the preferred method is to use a <<platform-scoped-eventing-system-configuration, Platform scoped Eventing System Configuration>>, while the service scoped configuration is reserved only for advanced use cases.
+====
+
+[#data-index-eventing-system-configuration]
+=== Data Index Eventing System configuration
+
+To configure a service scoped eventing system for the Data Index, you must use the field `spec.services.dataIndex.source.ref` in the `SonataFlowPlatform` CR to refer a specific Knative Eventing Broker.
+
+This information signals the {operator_name} to automatically link the Data Index to `consume` the {product_name} system events from that Broker.
+
+.Data Index service scoped eventing system configuration example
+[source,yam]
+----
+apiVersion: sonataflow.org/v1alpha08
+kind: SonataFlowPlatform
+metadata:
+  name: sonataflow-platform-example
+spec:
+  services:
+    dataIndex:
+      source:
+        ref:
+          name: data-index-source-example-broker <1>
+          namespace: data-index-source-example-broker-namespace <2>
+          apiVersion: eventing.knative.dev/v1
+          kind: Broker
+----
+
+<1> Name of the Knative Eventing Broker to `consume` events from.
+<2> Optional: Defines the namespace of the Knative Eventing Broker. Defaults to the SonataFlowPlatform namespace. In general, we recommend to create the Knative Eventing Broker in the same namespace as the SonataFlowPlatform.
+
+[NOTE]
+====
+In production environments, you must use a production-ready broker, like the link:{knative_eventing_kafka_broker_url}[Knative Kafka Broker].
+====
+
+[#jos-service-eventing-system-configuration]
+=== Jobs Service Eventing System configuration
+
+To configure a service scoped eventing system for the Jobs Service, you must use the fields `spec.services.jobService.source.ref` and `spec.services.jobService.sink.ref` in the `SonataFlowPlatform` CR.
+
+This information signals the {operator_name} to automatically link the Jobs Service to `consume` and `produce` the {product_name} system events from that configurations respectively.
+
+.Jobs Service scoped eventing system configuration example
+[source,yam]
+----
+apiVersion: sonataflow.org/v1alpha08
+kind: SonataFlowPlatform
+metadata:
+  name: sonataflow-platform-example
+spec:
+  services:
+    jobService:
+      source:
+        ref:
+          name: jobs-service-source-example-broker <1>
+          namespace: jobs-service-source-example-broker-namespace <2>
+          apiVersion: eventing.knative.dev/v1
+          kind: Broker
+      sink:
+        ref:
+          name: jobs-service-sink-example-broker <3>
+          namespace: jobs-service-sink-example-broker-namespace <4>
+          apiVersion: eventing.knative.dev/v1
+          kind: Broker
+----
+
+<1> Name of the Knative Eventing Broker to `consume` events from.
+<2> Optional: Defines the namespace of the Knative Eventing Broker. Defaults to the SonataFlowPlatform namespace. In general, we recommend to create the Knative Eventing Broker in the same namespace as the SonataFlowPlatform.
+<3> Name of the Knative Eventing Broker to `produce` events on.
+<4> Optional: Defines the namespace of the Knative Eventing Broker. Defaults to the SonataFlowPlatform namespace. In general, we recommend to create the Knative Eventing Broker in the same namespace as the SonataFlowPlatform.
+
+[NOTE]
+====
+In production environments, you must use production-ready brokers, like the link:{knative_eventing_kafka_broker_url}[Knative Kafka Broker].
+====
+
+[#cluster-scoped-eventing-system-configuration]
+=== Cluster scoped Eventing System configuration
+
+When you use a <<cluster-scoped-deployment>> deployment, the supporting services are automatically linked to the `Broker` configured in the `SonataFlowPlatform` CR referred by the `SonataFlowClusterPlatform` CR.
+
+=== Eventing System configuration precedence rules
+
+To configure the eventing system for a supporting service, the {operator_name} use the following precedence rules:
+
+* If the supporting service has a configured eventing system, by using any of the <<data-index-eventing-system-configuration>> or <<jos-service-eventing-system-configuration>> respectively, that configuration apply.
+
+* If the `SonataFlowPlatform` CR enclosing the supporting service, is configured with a <<platform-scoped-eventing-system-configuration>>, that configuration apply.
+
+* If the current cluster, is configured with a <<cluster-scoped-eventing-system-configuration>>, that configuration apply.
+
+* If none of the previous configurations exists, the supporting service is configured to produce direct Http calls to deliver events.
+
+=== Eventing System linking objects
+
+The linking of the supporting services with the Eventing System is produced by using Knative Eventing SinkBindings and Triggers.
+These objects are automatically created by the {operator_name}, and facilitate the events production and consumption from the supporting services.
+
+The example below shows the Knative Native eventing objects created for the following `SonataFlowPlatform` CR.
+
+.SonataFlowPlatform eventing system configuration example
+[source,yaml]
+----
+apiVersion: sonataflow.org/v1alpha08
+kind: SonataFlowPlatform
+metadata:
+  name: sonataflow-platform-example
+  namespace: example-namespace
+spec:
+  eventing:
+    broker:
+      ref:
+        name: example-broker <1>
+        apiVersion: eventing.knative.dev/v1
+        kind: Broker
+  services:
+    dataIndex: <2>
+      enabled: true
+    jobService: <3>
+      enabled: true
+----
+
+<1> Platform Broker configuration used by the Data Index, Jobs Service, and the workflows if not overridden.
+<2> Data Index ephemeral deployment.
+<3> Jobs Service ephemeral deployment.
+
+.Knative Kafka Broker example used by the SonataFlowPlatform
+[source,yaml]
+----
+apiVersion: eventing.knative.dev/v1
+kind: Broker
+metadata:
+  annotations:
+    eventing.knative.dev/broker.class: Kafka <1>
+  name: example-broker
+  namespace: example-namespace
+spec:
+  config:
+    apiVersion: v1
+    kind: ConfigMap
+    name: kafka-broker-config
+    namespace: knative-eventing
+----
+
+<1> Use the Kafka class to create a Kafka Knative Broker
+
+.Knative Eventing Triggers created for the Data Index and Jobs Service events consumption
+[source,bash]
+----
+kn trigger list -n example-namespace
+
+NAME                                                              BROKER           SINK                                                     AGE    CONDITIONS   READY   REASON
+data-index-jobs-fbf285df-c0a4-4545-b77a-c232ec2890e2              example-broker   service:sonataflow-platform-example-data-index-service   106s   7 OK / 7     True
+data-index-process-definition-e48b4e4bf73e22b90ecf7e093ff6b1eaf   example-broker   service:sonataflow-platform-example-data-index-service   106s   7 OK / 7     True
+data-index-process-error-fbf285df-c0a4-4545-b77a-c232ec2890e2     example-broker   service:sonataflow-platform-example-data-index-service   106s   7 OK / 7     True
+data-index-process-node-fbf285df-c0a4-4545-b77a-c232ec2890e2      example-broker   service:sonataflow-platform-example-data-index-service   106s   7 OK / 7     True
+data-index-process-sla-fbf285df-c0a4-4545-b77a-c232ec2890e2       example-broker   service:sonataflow-platform-example-data-index-service   106s   7 OK / 7     True
+data-index-process-state-fbf285df-c0a4-4545-b77a-c232ec2890e2     example-broker   service:sonataflow-platform-example-data-index-service   106s   7 OK / 7     True
+data-index-process-variable-ac727d6051750888dedb72f697737c0dfbf   example-broker   service:sonataflow-platform-example-data-index-service   106s   7 OK / 7     True
+
+jobs-service-create-job-fbf285df-c0a4-4545-b77a-c232ec2890e2      example-broker   service:sonataflow-platform-example-jobs-service         106s   7 OK / 7     True
+jobs-service-delete-job-fbf285df-c0a4-4545-b77a-c232ec2890e2      example-broker   service:sonataflow-platform-example-jobs-service         106s   7 OK / 7     True
+----
+
+.Knative Eventing SinkBinding created for the Jobs Service events production
+[source,bash]
+----
+kn source list -n example-namespace
+
+NAME                                          TYPE          RESOURCE                           SINK                    READY
+sonataflow-platform-example-jobs-service-sb   SinkBinding   sinkbindings.sources.knative.dev   broker:example-broker   True
+----
+
 == Advanced Supporting Services Configurations
 
 To configure the advanced options for any of the supporting services you must use the `podTemplate` field respectively, for example `dataIndex.podTemplate`:

--- a/serverlessworkflow/modules/ROOT/pages/cloud/operator/supporting-services.adoc
+++ b/serverlessworkflow/modules/ROOT/pages/cloud/operator/supporting-services.adoc
@@ -309,7 +309,7 @@ spec:
 ----
 
 <1> Name of the Knative Eventing Broker to `consume` events from.
-<2> Optional: Defines the namespace of the Knative Eventing Broker. Defaults to the SonataFlowPlatform namespace. In general, we recommend to create the Knative Eventing Broker in the same namespace as the SonataFlowPlatform.
+<2> Optional: Defines the namespace of the Knative Eventing Broker. Defaults to the SonataFlowPlatform namespace. In general, we recommend creating the Knative Eventing Broker in the same namespace as the SonataFlowPlatform.
 <3> Name of the Knative Eventing Broker to `produce` events on.
 <4> Optional: Defines the namespace of the Knative Eventing Broker. Defaults to the SonataFlowPlatform namespace. In general, we recommend to create the Knative Eventing Broker in the same namespace as the SonataFlowPlatform.
 

--- a/serverlessworkflow/modules/ROOT/pages/cloud/operator/supporting-services.adoc
+++ b/serverlessworkflow/modules/ROOT/pages/cloud/operator/supporting-services.adoc
@@ -340,7 +340,7 @@ To configure the eventing system for a supporting service, the {operator_name} u
 The linking of the supporting services with the Eventing System is produced by using Knative Eventing SinkBindings and Triggers.
 These objects are automatically created by the {operator_name}, and facilitate the events production and consumption from the supporting services.
 
-The example below shows the Knative Native eventing objects created for the following `SonataFlowPlatform` CR.
+The following example shows the Knative Native eventing objects created for the `SonataFlowPlatform` CR:
 
 .SonataFlowPlatform eventing system configuration example
 [source,yaml]

--- a/serverlessworkflow/modules/ROOT/pages/cloud/operator/supporting-services.adoc
+++ b/serverlessworkflow/modules/ROOT/pages/cloud/operator/supporting-services.adoc
@@ -280,7 +280,7 @@ In production environments, you must use a production-ready broker, like the lin
 [#jos-service-eventing-system-configuration]
 === Jobs Service Eventing system configuration
 
-To configure a service scoped eventing system for the Jobs Service, you must use the fields `spec.services.jobService.source.ref` and `spec.services.jobService.sink.ref` in the `SonataFlowPlatform` CR.
+To configure a service-scoped eventing system for the Jobs Service, you must use the fields `spec.services.jobService.source.ref` and `spec.services.jobService.sink.ref` in the `SonataFlowPlatform` CR.
 
 This information signals the {operator_name} to automatically link the Jobs Service to `consume` and `produce` the {product_name} system events from that configurations respectively.
 

--- a/serverlessworkflow/modules/ROOT/pages/cloud/operator/supporting-services.adoc
+++ b/serverlessworkflow/modules/ROOT/pages/cloud/operator/supporting-services.adoc
@@ -282,7 +282,7 @@ In production environments, you must use a production-ready broker, like the lin
 
 To configure a service-scoped eventing system for the Jobs Service, you must use the fields `spec.services.jobService.source.ref` and `spec.services.jobService.sink.ref` in the `SonataFlowPlatform` CR.
 
-This information signals the {operator_name} to automatically link the Jobs Service to `consume` and `produce` the {product_name} system events from that configurations respectively.
+This information signals the {operator_name} to automatically link the Jobs Service to `consume` and `produce` the {product_name} system events from that configuration respectively.
 
 .Jobs Service scoped eventing system configuration example
 [source,yam]

--- a/serverlessworkflow/modules/ROOT/pages/cloud/operator/supporting-services.adoc
+++ b/serverlessworkflow/modules/ROOT/pages/cloud/operator/supporting-services.adoc
@@ -278,7 +278,7 @@ In production environments, you must use a production-ready broker, like the lin
 ====
 
 [#jos-service-eventing-system-configuration]
-=== Jobs Service Eventing System configuration
+=== Jobs Service Eventing system configuration
 
 To configure a service scoped eventing system for the Jobs Service, you must use the fields `spec.services.jobService.source.ref` and `spec.services.jobService.sink.ref` in the `SonataFlowPlatform` CR.
 

--- a/serverlessworkflow/modules/ROOT/pages/cloud/operator/supporting-services.adoc
+++ b/serverlessworkflow/modules/ROOT/pages/cloud/operator/supporting-services.adoc
@@ -319,7 +319,7 @@ In production environments, you must use production-ready brokers, like the link
 ====
 
 [#cluster-scoped-eventing-system-configuration]
-=== Cluster scoped Eventing System configuration
+=== Cluster-scoped Eventing system configuration
 
 When you use a <<cluster-scoped-deployment>> deployment, the supporting services are automatically linked to the `Broker` configured in the `SonataFlowPlatform` CR referred by the `SonataFlowClusterPlatform` CR.
 

--- a/serverlessworkflow/modules/ROOT/pages/cloud/operator/supporting-services.adoc
+++ b/serverlessworkflow/modules/ROOT/pages/cloud/operator/supporting-services.adoc
@@ -180,7 +180,7 @@ When you use the common PostgreSQL configuration, the database schema for each s
 For example, `sonataflow-platform-example-data-index-service`.
 ====
 
-== Configuring the Supporting Services Eventing System
+== Configuring the supporting services Eventing system
 
 In general, the following events are produced in a {product_name} installation:
 

--- a/serverlessworkflow/modules/ROOT/pages/cloud/operator/supporting-services.adoc
+++ b/serverlessworkflow/modules/ROOT/pages/cloud/operator/supporting-services.adoc
@@ -198,7 +198,7 @@ In a regular {product_name} installation, the preferred method is to use the <<p
 [#platform-scoped-eventing-system-configuration]
 === Platform-scoped Eventing system configuration
 
-To configure a platform scoped eventing system, you must use the field `spec.eventing.broker.ref` in the `SonataFlowPlatform` CR to refer a Knative Eventing Broker.
+To configure a platform-scoped eventing system, you must use the field `spec.eventing.broker.ref` in the `SonataFlowPlatform` CR to refer to a Knative Eventing Broker.
 
 This information signals the {operator_name} to automatically link the supporting services to `produce` and `consume` the events by using that Broker.
 

--- a/serverlessworkflow/modules/ROOT/pages/cloud/operator/supporting-services.adoc
+++ b/serverlessworkflow/modules/ROOT/pages/cloud/operator/supporting-services.adoc
@@ -321,7 +321,7 @@ In production environments, you must use production-ready brokers, like the link
 [#cluster-scoped-eventing-system-configuration]
 === Cluster-scoped Eventing system configuration
 
-When you use a <<cluster-scoped-deployment>> deployment, the supporting services are automatically linked to the `Broker` configured in the `SonataFlowPlatform` CR referred by the `SonataFlowClusterPlatform` CR.
+When you use a <<cluster-scoped-deployment>> deployment, the supporting services are automatically linked to the `Broker` configured in the `SonataFlowPlatform` CR referred to by the `SonataFlowClusterPlatform` CR.
 
 === Eventing System configuration precedence rules
 


### PR DESCRIPTION

<!-- Please don't forget your Issue link -->
Closes:  #664 

<!-- Please provide a short description of what this PR does -->
**Description:**

<!-- Link to related PRs: -->

Please make sure that your PR meets the following requirements:

- [X] You have read the [contributions doc](https://github.com/apache/incubator-kie-kogito-docs/blob/main/CONTRIBUTING.md)
- [X] Pull Request title is properly formatted: `Issue-XYZ Subject`
- [X] Pull Request title contains the target branch if not targeting main: `[0.9.x] Issue-XYZ Subject`
- [X] The nav.adoc file has a link to this guide in the proper category
- [X] The index.adoc file has a card to this guide in the proper category, with a meaningful description

<details>
<summary>
How to backport a pull request to a different branch?
</summary>

In order to automatically create a **backporting pull request** please add one or more labels having the following format `backport-<branch-name>`, where `<branch-name>` is the name of the branch where the pull request must be backported to (e.g., `backport-7.67.x` to backport the original PR to the `7.67.x` branch).

> **NOTE**: **backporting** is an action aiming to move a change (usually a commit) from a branch (usually the main one) to another one, which is generally referring to a still maintained release branch. Keeping it simple: it is about to move a specific change or a set of them from one branch to another.

Once the original pull request is successfully merged, the automated action will create one backporting pull request per each label (with the previous format) that has been added.

If something goes wrong, the author will be notified and at this point a manual backporting is needed.

> **NOTE**: this automated backporting is triggered whenever a pull request on `main` branch is labeled or closed, but both conditions must be satisfied to get the new PR created.
</details>