### PR TITLE
NO-ISSUE: Update antora-playbook.yml so the website points to main

### DIFF
--- a/antora-playbook.yml
+++ b/antora-playbook.yml
@@ -2,7 +2,7 @@ site:
   title: SonataFlow Guides
   start_page: serverlessworkflow::index.adoc
 urls:
-  latest_version_segment: latest
+  latest_version_segment: main
 antora:
   extensions:
   - require: '@antora/lunr-extension'
@@ -12,25 +12,6 @@ content:
   - url: git@github.com:apache/incubator-kie-kogito-docs.git
     branches:
     - main
-    - 1.24.x
-    - 1.25.x
-    - 1.26.x
-    - 1.27.x
-    - 1.28.x
-    - 1.29.x
-    - 1.30.x
-    - 1.31.x
-    - 1.32.x
-    - 1.33.x
-    - 1.34.x
-    - 1.35.x
-    - 1.36.x
-    - 1.37.x
-    - 1.38.x
-    - 1.39.x
-    - 1.40.x
-    - 1.41.x
-    - 1.42.x
     - 1.43.x
     - 1.44.x
     - 1.45.x


### PR DESCRIPTION
As per current development practices, we should point to snapshot to not confuse users with deprecated references.

