### PR TITLE
[10.0.x] NO_ISSUE: Fix URL to use tagged opeator.yml for 10.0.0

### DIFF
--- a/serverlessworkflow/antora.yml
+++ b/serverlessworkflow/antora.yml
@@ -110,7 +110,7 @@ asciidoc:
     images_distributions_url: https://kie.apache.org/docs/start/download#container-images
     apple_support_url: https://support.apple.com/guide/mac-help/open-a-mac-app-from-an-unknown-developer-mh40616/mac
     kogito_examples_repository_url: https://github.com/apache/incubator-kie-kogito-examples
-    kogito_operator_repository_rawcontent_url: https://raw.githubusercontent.com/apache/incubator-kie-tools/refs/heads/{operator_version}/packages/sonataflow-operator
+    kogito_operator_repository_rawcontent_url: https://raw.githubusercontent.com/apache/incubator-kie-tools/refs/tags/{kogito_version}/packages/sonataflow-operator
     kogito_sw_examples_url: https://github.com/apache/incubator-kie-kogito-examples/tree/main/serverless-workflow-examples
     kogito_sw_operator_examples_url: https://github.com/apache/incubator-kie-kogito-examples/tree/main/serverless-operator-examples
     kogito_examples_url: https://github.com/apache/incubator-kie-kogito-examples.git


### PR DESCRIPTION
Fixes operator rawcontent URL for the yml file used to manually install operator.

Only for `10.0.x` for next releases and on main I ll work on better solution