### PR TITLE
NO-ISSUE: Clarify that `.spec.resources`  is ignored in gitops

### DIFF
--- a/serverlessworkflow/modules/ROOT/pages/cloud/operator/referencing-resource-files.adoc
+++ b/serverlessworkflow/modules/ROOT/pages/cloud/operator/referencing-resource-files.adoc
@@ -14,6 +14,15 @@ For example, when doing xref:service-orchestration/orchestration-of-openapi-base
 
 If these files are not in a remote location that can be accessed via the HTTP protocol, you must describe in the `SonataFlow` CR where to find them within the cluster. This is done via link:{kubernetes_configmap_url}[`ConfigMaps`].
 
+[IMPORTANT]
+====
+The `.spec.resources` section is **ignored in the `preview` profile**.
+
+To use referenced external files like OpenAPI specs or schemas, make sure your workflow is running under a supported profile such as `dev` or `gitops`.
+
+See more in xref:cloud/operator/deployment-profile.adoc#_profile_implications_for_customization[Deployment Profile Implications].
+====
+
 == Creating ConfigMaps with Workflow referencing additional files
 
 .Prerequisites
@@ -55,7 +64,7 @@ spec:
     end: true
 ----
 
-<1> The workflow defines an input schema
+<1> The workflow defines an input schema  
 <2> The workflow requires an OpenAPI specification file to make a REST invocation
 
 The `Hello Service` workflow in the example offers two options. You can either create two `ConfigMaps`, each for one file, to have a clear separation of concerns or group them into one.
@@ -77,7 +86,7 @@ Replace `<workflow-namespace>` with the namespace where you are going to deploy 
 
 You should have a `ConfigMap` with two data entries similar to this one:
 
-.Example of a ConfigMap containing the data for the worflow
+.Example of a ConfigMap containing the data for the workflow
 [source,yaml,subs="attributes+"]
 ----
 kind: ConfigMap
@@ -92,6 +101,11 @@ data:
 ----
 
 Now you can add reference to this `ConfigMap` into your `SonataFlow` CR:
+
+[NOTE]
+====
+The following example only works in profiles that support `.spec.resources`, such as `dev` or `gitops`. It **does not work** under the `preview` profile.
+====
 
 .SonataFlow CR referencing a ConfigMap resource
 [source,yaml,subs="attributes+"]
@@ -127,8 +141,8 @@ spec:
     end: true
 ----
 
-<1> Introduced a new attribute `.spec.resources` where you can bind the `ConfigMap` to the `SonataFlow` CR
-<2> The name of the `ConfigMap` in the same namespace
+<1> Introduced a new attribute `.spec.resources` where you can bind the `ConfigMap` to the `SonataFlow` CR  
+<2> The name of the `ConfigMap` in the same namespace  
 <3> The path where we want to reference these files
 
 Note that the `workflowPath` is `specs`. This is the path where you want to reference the files within the `ConfigMap` in the workflow definition.

--- a/serverlessworkflow/modules/ROOT/pages/cloud/operator/referencing-resource-files.adoc
+++ b/serverlessworkflow/modules/ROOT/pages/cloud/operator/referencing-resource-files.adoc
@@ -16,9 +16,9 @@ If these files are not in a remote location that can be accessed via the HTTP pr
 
 [IMPORTANT]
 ====
-The `.spec.resources` section is **ignored in the `preview` profile**.
+The `.spec.resources` section is **ignored in the `gitops` profile**.
 
-To use referenced external files like OpenAPI specs or schemas, make sure your workflow is running under a supported profile such as `dev` or `gitops`.
+To use referenced external files like OpenAPI specs or schemas, make sure your workflow is running under a supported profile such as `dev` or `preview`.
 
 See more in xref:cloud/operator/deployment-profile.adoc#_profile_implications_for_customization[Deployment Profile Implications].
 ====
@@ -104,7 +104,7 @@ Now you can add reference to this `ConfigMap` into your `SonataFlow` CR:
 
 [NOTE]
 ====
-The following example only works in profiles that support `.spec.resources`, such as `dev` or `gitops`. It **does not work** under the `preview` profile.
+The following example only works in profiles that support `.spec.resources`, such as `dev` or `preview`. It **does not work** under the `gitops` profile.
 ====
 
 .SonataFlow CR referencing a ConfigMap resource


### PR DESCRIPTION
<!-- Please don't forget your Issue link -->

<!-- Please provide a short description of what this PR does -->
**Description:**
In this PR, we added a few notes about the operator ignoring `.specs.resources` in the gitops profile.

<!-- Link to related PRs: -->

Please make sure that your PR meets the following requirements:

- [ ] You have read the [contributions doc](https://github.com/apache/incubator-kie-kogito-docs/blob/main/CONTRIBUTING.md)
- [ ] Pull Request title is properly formatted: `Issue-XYZ Subject`
- [ ] Pull Request title contains the target branch if not targeting main: `[0.9.x] Issue-XYZ Subject`
- [ ] The nav.adoc file has a link to this guide in the proper category
- [ ] The index.adoc file has a card to this guide in the proper category, with a meaningful description

<details>
<summary>
How to backport a pull request to a different branch?
</summary>

In order to automatically create a **backporting pull request** please add one or more labels having the following format `backport-<branch-name>`, where `<branch-name>` is the name of the branch where the pull request must be backported to (e.g., `backport-7.67.x` to backport the original PR to the `7.67.x` branch).

> **NOTE**: **backporting** is an action aiming to move a change (usually a commit) from a branch (usually the main one) to another one, which is generally referring to a still maintained release branch. Keeping it simple: it is about to move a specific change or a set of them from one branch to another.

Once the original pull request is successfully merged, the automated action will create one backporting pull request per each label (with the previous format) that has been added.

If something goes wrong, the author will be notified and at this point a manual backporting is needed.

> **NOTE**: this automated backporting is triggered whenever a pull request on `main` branch is labeled or closed, but both conditions must be satisfied to get the new PR created.
</details>