### PR TITLE
NO_ISSUE: Fix release issues for 10.1.x SonataFlow docs

### DIFF
--- a/antora-playbook.yml
+++ b/antora-playbook.yml
@@ -11,8 +11,6 @@ content:
   sources:
   - url: git@github.com:apache/incubator-kie-kogito-docs.git
     branches:
-    - main
-    - 10.0.x
     - 10.1.x
     start_path: serverlessworkflow
 runtime:

--- a/serverlessworkflow/antora.yml
+++ b/serverlessworkflow/antora.yml
@@ -19,9 +19,8 @@
 
 name: serverlessworkflow
 title: "SonataFlow Guides"
-version: main
-display_version: snapshot
-prerelease: snapshot
+version: '10.1.0'
+display_version: '10.1.0'
 start_page: index.adoc
 nav:
 - "modules/ROOT/nav.adoc"


### PR DESCRIPTION
Fix for issue found by @tkobayas  in https://github.com/apache/incubator-kie-website/pull/43

Adds missing version declarations and removes prerelease config.