### PR TITLE
Fix apache/incubator-kie-issues#1905 - add doc about header perisistence

### DIFF
--- a/serverlessworkflow/modules/ROOT/pages/core/configuration-properties.adoc
+++ b/serverlessworkflow/modules/ROOT/pages/core/configuration-properties.adoc
@@ -35,6 +35,18 @@ a|Defines the type of persistence database. The possible values of this property
 |`false`
 |Yes
 
+|`kogito.persistence.headers.enabled`
+|Enables or disables the persistence of the input request header.
+|boolean
+|`false`
+|Yes
+
+|`kogito.persistence.headers.excluded`
+|List of headers from the input request to exclude from persistence. Only applicable if kogito.persistence.headers.enabled=true
+|list
+|`<empty>`
+|Yes
+
 |`kogito.workflow.version-strategy`
 | Defines strategy to resolve a process version to use. The possible values of this property include:
 


### PR DESCRIPTION
<!-- Please don't forget your Issue link -->
Fix  apache/incubator-kie-issues#1905

<!-- Please provide a short description of what this PR does -->
**Description:**
add doc about header perisistence
<!-- Link to related PRs: -->

Please make sure that your PR meets the following requirements:

- [ ] You have read the [contributions doc](https://github.com/apache/incubator-kie-kogito-docs/blob/main/CONTRIBUTING.md)
- [ ] Pull Request title is properly formatted: `Issue-XYZ Subject`
- [ ] Pull Request title contains the target branch if not targeting main: `[0.9.x] Issue-XYZ Subject`
- [ ] The nav.adoc file has a link to this guide in the proper category
- [ ] The index.adoc file has a card to this guide in the proper category, with a meaningful description

<details>
<summary>
How to backport a pull request to a different branch?
</summary>

In order to automatically create a **backporting pull request** please add one or more labels having the following format `backport-<branch-name>`, where `<branch-name>` is the name of the branch where the pull request must be backported to (e.g., `backport-7.67.x` to backport the original PR to the `7.67.x` branch).

> **NOTE**: **backporting** is an action aiming to move a change (usually a commit) from a branch (usually the main one) to another one, which is generally referring to a still maintained release branch. Keeping it simple: it is about to move a specific change or a set of them from one branch to another.

Once the original pull request is successfully merged, the automated action will create one backporting pull request per each label (with the previous format) that has been added.

If something goes wrong, the author will be notified and at this point a manual backporting is needed.

> **NOTE**: this automated backporting is triggered whenever a pull request on `main` branch is labeled or closed, but both conditions must be satisfied to get the new PR created.
</details>