### PR TITLE
Issue-738 SonataFlow 'Data Index standalone service' doc quay.io image reference

### DIFF
--- a/serverlessworkflow/modules/ROOT/pages/data-index/data-index-service.adoc
+++ b/serverlessworkflow/modules/ROOT/pages/data-index/data-index-service.adoc
@@ -60,7 +60,7 @@ Here you can see in example, how the {data_index_ref} resource definition can be
 ----
   data-index:
     container_name: data-index
-    image: quay.io/kiegroup/kogito-data-index-postgresql:latest <1>
+    image: {sonataflow_dataindex_postgresql_imagename}:{operator_version} <1>
     ports:
       - "8180:8080"
     depends_on:
@@ -154,7 +154,7 @@ spec:
     spec:
       containers:
         - name: data-index-service-postgresql
-          image: quay.io/kiegroup/kogito-data-index-postgresql:latest <1>
+          image: {sonataflow_dataindex_postgresql_imagename}:{operator_version} <1>
           imagePullPolicy: Always
           ports:
             - containerPort: 8080

--- a/serverlessworkflow/modules/ROOT/pages/data-index/data-index-service.adoc
+++ b/serverlessworkflow/modules/ROOT/pages/data-index/data-index-service.adoc
@@ -56,7 +56,7 @@ For this purpose, it is important to make sure the following addons are included
 Here you can see in example, how the {data_index_ref} resource definition can be deployed as part of a docker-compose definition
 
 .Example of `DataIndex` resource in a docker-compose deployment using Kafka eventing:
-[source,yaml]
+[source,yaml,subs="attributes+"]
 ----
   data-index:
     container_name: data-index
@@ -114,7 +114,7 @@ More details about customizing Quarkus generated images can be found in {quarkus
 This deployment definition resource shows how the {data_index_ref} service configured and deployed can connect with an existing PostgreSQL database and to consume Knative events.
 
 .Example `DataIndex` resource with PostgreSQL persistence and Knative eventing in a kubernetes environment :
-[source,yaml]
+[source,yaml,subs="attributes+"]
 ----
 apiVersion: v1
 kind: Service


### PR DESCRIPTION
Refers to #738 

Changes example docker-compose data-index image from obsolete quay.io/kiegroup/... to {sonataflow_dataindex_postgresql_imagename}:{operator_version}

Please make sure that your PR meets the following requirements:

- [x] You have read the [contributions doc](https://github.com/apache/incubator-kie-kogito-docs/blob/main/CONTRIBUTING.md)
- [x] Pull Request title is properly formatted: `Issue-XYZ Subject`
- [x] Pull Request title contains the target branch if not targeting main: `[0.9.x] Issue-XYZ Subject`
- [x] The nav.adoc file has a link to this guide in the proper category
- [x] The index.adoc file has a card to this guide in the proper category, with a meaningful description
